### PR TITLE
Load pak files

### DIFF
--- a/SatisfactoryModLoader.vcxproj
+++ b/SatisfactoryModLoader.vcxproj
@@ -162,6 +162,8 @@
     <ClInclude Include="SatisfactoryModLoader\event\game\BeginPlayEvent.h" />
     <ClInclude Include="SatisfactoryModLoader\event\game\EnterChatMessageEvent.h" />
     <ClInclude Include="SatisfactoryModLoader\event\game\FoliagePickupEvent.h" />
+    <ClInclude Include="SatisfactoryModLoader\event\game\GetLocalizedPackagePath.h" />
+    <ClInclude Include="SatisfactoryModLoader\event\game\GetPakSigningKeys.h" />
     <ClInclude Include="SatisfactoryModLoader\event\game\InventoryHasAuthorityEvent.h" />
     <ClInclude Include="SatisfactoryModLoader\event\game\SuicideEvent.h" />
     <ClInclude Include="SatisfactoryModLoader\event\game\TakeDamageEvent.h" />

--- a/SatisfactoryModLoader/event/Event.h
+++ b/SatisfactoryModLoader/event/Event.h
@@ -10,6 +10,8 @@ enum EventType {
 	OnPlayerEnterChatMessage,
 	OnPlayerSuicide,
 	OnInventoryHasAuthority,
+	GetPakSigningKeys,
+	GetLocalizedPackagePath,
 	END
 };
 

--- a/SatisfactoryModLoader/event/EventLoader.cpp
+++ b/SatisfactoryModLoader/event/EventLoader.cpp
@@ -13,6 +13,8 @@
 #include <event/game/TakeDamageEvent.h>
 #include <event/game/SuicideEvent.h>
 #include <event/game/BeginPlayEvent.h>
+#include <event/game/GetPakSigningKeys.h>
+#include <event/game/GetLocalizedPackagePath.h>
 
 // holds a cache of the global mod list
 std::vector<Mod> _modList;
@@ -38,6 +40,12 @@ void EventLoader::load_events(std::vector<Mod> mods) {
 
 	BeginPlayEvent e6;
 	hook_event(e6, BeginPlayEvent::use);
+
+	GetPakSigningKeysEvent e7;
+	hook_event(e7, GetPakSigningKeysEvent::use);
+
+	GetLocalizedPackagePathEvent e8;
+	hook_event(e8, GetLocalizedPackagePathEvent::use);
 }
 
 // run a mod's setup function

--- a/SatisfactoryModLoader/event/game/GetLocalizedPackagePath.h
+++ b/SatisfactoryModLoader/event/game/GetLocalizedPackagePath.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <event/Event.h>
+#include <util/Utility.h>
+#include <event/EventLoader.h>
+#include <util/FString.h>
+
+class GetLocalizedPackagePathEvent : public Event {
+public:
+	GetLocalizedPackagePathEvent();
+	virtual ~GetLocalizedPackagePathEvent();
+
+	static constexpr EventType descriptor = EventType::GetLocalizedPackagePath;
+
+	static constexpr const char* addressName = "FPackageName::GetLocalizedPackagePath";
+
+	virtual EventType type() const {
+		return descriptor;
+	}
+
+	virtual const char* name() const {
+		return addressName;
+	}
+
+	// FString FPackageName::GetLocalizedPackagePath(const FString& InSourcePackagePath)
+	static FString* use(void* packageName, FString* InSourcePackagePath) { // TODO: turn that pointer back to a reference?
+
+		//// mod functions
+		auto modFunction = (ModFunc)originalFunctions[descriptor].ModFunction;
+		std::vector<void*> args = {
+			packageName,
+			InSourcePackagePath
+		};
+		// std::vector<void*>&
+		modFunction(GetLocalizedPackagePathEvent(), args);
+
+
+		auto pointer = (GetLocalizedPackagePathFunction)originalFunctions[descriptor].Function;
+		return pointer(packageName, InSourcePackagePath);
+	}
+
+private:
+	typedef FString*(WINAPI* GetLocalizedPackagePathFunction)(void*, FString*);
+};
+
+GetLocalizedPackagePathEvent::GetLocalizedPackagePathEvent() {
+}
+
+
+GetLocalizedPackagePathEvent::~GetLocalizedPackagePathEvent() {
+}

--- a/SatisfactoryModLoader/event/game/GetPakSigningKeys.h
+++ b/SatisfactoryModLoader/event/game/GetPakSigningKeys.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <event/Event.h>
+#include <util/Utility.h>
+#include <event/EventLoader.h>
+
+class GetPakSigningKeysEvent : public Event {
+public:
+	GetPakSigningKeysEvent();
+	virtual ~GetPakSigningKeysEvent();
+
+	static constexpr EventType descriptor = EventType::GetPakSigningKeys;
+
+	static constexpr const char* addressName = "FPakPlatformFile::GetPakSigningKeys";
+
+	virtual EventType type() const {
+		return descriptor;
+	}
+
+	virtual const char* name() const {
+		return addressName;
+	}
+
+	// void FPakPlatformFile::GetPakSigningKeys(FEncryptionKey& OutKey)
+	static void use(void* OutKey) {
+		log("Prevent pak signing keys from being read.");
+		// We don't do anything, so that the Unreal Engine thinks it does not need to check the signature of pak files
+		// auto pointer = (GetLocalizedPackagePathFunction)originalFunctions[descriptor].Function;
+		// pointer(OutKey);
+	}
+
+private:
+	typedef void(WINAPI* GetLocalizedPackagePathFunction)(void*);
+};
+
+GetPakSigningKeysEvent::GetPakSigningKeysEvent() {
+}
+
+
+GetPakSigningKeysEvent::~GetPakSigningKeysEvent() {
+}

--- a/TestMod/ModEvents.cpp
+++ b/TestMod/ModEvents.cpp
@@ -10,6 +10,7 @@
 #include <event/game/TakeDamageEvent.h>
 #include <event/game/EnterChatMessageEvent.h>
 #include <event/game/BeginPlayEvent.h>
+#include <event/game/GetLocalizedPackagePath.h>
 
 void send_back(const Event& event, std::vector<void*>& data) {
 	FARPROC proc = get_function((HMODULE)0x0000000180000000, "recieve_from_mod");
@@ -34,9 +35,29 @@ void OnPlayerChatMessageSent(std::vector<void*>& args) {
 	}
 }
 
+void DoGetLocalizedPackagePath(std::vector<void*>& args) {
+	// Redirect some asset files to our pak
+
+	FString* InSourcePackagePath = (FString*) args[1];
+	char* chars = new char[InSourcePackagePath->length];
+	for (size_t i = 0; i < InSourcePackagePath->length; i++) {
+		chars[i] = InSourcePackagePath->data[i];
+	}
+
+	if (strcmp(chars, "/Game/FactoryGame/Interface/UI/Assets/Logo/SatisfactoryLogotype_EarlyAccess") == 0
+		|| strcmp(chars, "/Game/FactoryGame/Interface/UI/Assets/MainMenu/NewsDefaultImage") == 0
+		|| strcmp(chars, "/Game/FactoryGame/Buildable/Factory/ConstructorMk1/Mesh/ConstructorMk1_static") == 0) {
+		// Load from FactoryLame package instead of FactoryGame
+		InSourcePackagePath->data[13] = 'L';
+	}
+	delete chars;
+}
+
 EXTERN_DLL_EXPORT void setup() {
 	dispatcher.subscribe(TakeDamageEvent::descriptor, OnPlayerTakenDamage);
 	dispatcher.subscribe(EnterChatMessageEvent::descriptor, OnPlayerChatMessageSent);
+	dispatcher.subscribe(GetLocalizedPackagePathEvent::descriptor, DoGetLocalizedPackagePath);
+
 }
 
 EXTERN_DLL_EXPORT std::vector<void*> run_event(const Event& event, std::vector<void*>& args) {

--- a/TestMod/ModEvents.cpp
+++ b/TestMod/ModEvents.cpp
@@ -38,7 +38,7 @@ void OnPlayerChatMessageSent(std::vector<void*>& args) {
 void DoGetLocalizedPackagePath(std::vector<void*>& args) {
 	// Redirect some asset files to our pak
 
-	FString* InSourcePackagePath = (FString*) args[1];
+	FString* InSourcePackagePath = (FString*)args[1];
 	char* chars = new char[InSourcePackagePath->length];
 	for (size_t i = 0; i < InSourcePackagePath->length; i++) {
 		chars[i] = InSourcePackagePath->data[i];
@@ -46,7 +46,8 @@ void DoGetLocalizedPackagePath(std::vector<void*>& args) {
 
 	if (strcmp(chars, "/Game/FactoryGame/Interface/UI/Assets/Logo/SatisfactoryLogotype_EarlyAccess") == 0
 		|| strcmp(chars, "/Game/FactoryGame/Interface/UI/Assets/MainMenu/NewsDefaultImage") == 0
-		|| strcmp(chars, "/Game/FactoryGame/Buildable/Factory/ConstructorMk1/Mesh/ConstructorMk1_static") == 0) {
+		|| strcmp(chars, "/Game/FactoryGame/Buildable/Factory/ConstructorMk1/Mesh/ConstructorMk1_static") == 0
+		|| strcmp(chars, "/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk1/Mesh/ConveyorBeltMk1_static") == 0) {
 		// Load from FactoryLame package instead of FactoryGame
 		InSourcePackagePath->data[13] = 'L';
 	}

--- a/xinput1_3/xinput1_3.cpp
+++ b/xinput1_3/xinput1_3.cpp
@@ -13,6 +13,7 @@ LPCSTR mImportNames[] = {"DllMain", "XInputEnable", "XInputGetBatteryInformation
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved ) {
 	mHinst = hinstDLL;
 	if (fdwReason == DLL_PROCESS_ATTACH) {
+		mod_loader_entry();
 		load_original_dll();
 		for (int i = 0; i < 12; i++)
 			mProcs[i] = (UINT_PTR)GetProcAddress(mHinstDLL, mImportNames[i]);
@@ -26,7 +27,7 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved ) {
 	}
 	if ( fdwReason == DLL_THREAD_ATTACH) {
 		hooked = true;
-		mod_loader_entry();
+		//mod_loader_entry();
 	}
 	return ( TRUE );
 }


### PR DESCRIPTION
Adds ability to load additional assets from an unsigned pak file.

Currently requires the `mod_loader_entry()` to be called in `DLL_PROCESS_ATTACH` to hook `FPakPlatformFile::GetPakSigningKeys`.

There is `Mod-Test1.pak` included to test this, but here is a guide to create your own pak file https://github.com/bitowl/SatisfactoryModLoader/wiki/Create-a-pak-file