### PR TITLE
Use default values when reading config

### DIFF
--- a/SatisfactoryModLoader/SatisfactoryModLoader.cpp
+++ b/SatisfactoryModLoader/SatisfactoryModLoader.cpp
@@ -87,18 +87,9 @@ void read_config() {
 
 	loaderConfig.load();
 
-	loadConsole = loaderConfig.get<bool>("Console");
-	if (loadConsole == NULL) {
-		loadConsole = true;
-	}
-	debugOutput = loaderConfig.get<bool>("Debug");
-	if (debugOutput == NULL) {
-		debugOutput = false;
-	}
-	supressErrors = loaderConfig.get<bool>("SupressErrors");
-	if (supressErrors == NULL) {
-		supressErrors = false;
-	}
+	loadConsole = loaderConfig.get<bool>("Console", true);
+	debugOutput = loaderConfig.get<bool>("Debug", false);
+	supressErrors = loaderConfig.get<bool>("SupressErrors", false);
 }
 
 //cleans up when the program is killed

--- a/SatisfactoryModLoader/util/Configuration.h
+++ b/SatisfactoryModLoader/util/Configuration.h
@@ -18,14 +18,14 @@ public:
 	}
 
 	template<typename T>
-	T get(const char* name) {
+	T get(const char* name, T defaultValue) {
 		if (_data.contains(name)) {
 			return _data[name];
 		}
-		else {
-			error("Key does not exist: ", name);
-			return NULL;
-		}
+
+		error("Key does not exist: ", name);
+		set(name, defaultValue);
+		return defaultValue;
 	}
 
 	void save();


### PR DESCRIPTION
With the current method you're checking if a value is `NULL` which is also `false`. So if a value inside the config is `false` it always fallbacks to the default value.

This pull request introduces an `defaultValue` parameter, which the method fallbacks to if the requested key cannot be found, writes the selected `defaultValue` to the config and returns it.