### PR TITLE
Fixes for Editor and Game Crash

### DIFF
--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeBase.cpp
@@ -7,7 +7,7 @@
 
 AFGBuildablePipeBase::AFGBuildablePipeBase() : Super() {
 	this->mSplineComponent = CreateDefaultSubobject<USplineComponent>(TEXT("SplineComponent")); this->mSplineComponent->SetupAttachment(this->RootComponent);
-	this->mInstancedSplineComponent = CreateDefaultSubobject<UFGInstancedSplineMeshComponent>(TEXT("InstancedSplineComponent")); this->mInstancedSplineComponent->SetupAttachment(this->RootComponent);
+	//this->mInstancedSplineComponent = CreateDefaultSubobject<UFGInstancedSplineMeshComponent>(TEXT("InstancedSplineComponent")); this->mInstancedSplineComponent->SetupAttachment(this->RootComponent);
 	this->mHologramClass = AFGPipelineHologram::StaticClass();
 	this->MaxRenderDistance = -1;
 	this->mFactoryTickFunction.TickGroup = TG_PrePhysics; this->mFactoryTickFunction.EndTickGroup = TG_PrePhysics; this->mFactoryTickFunction.bTickEvenWhenPaused = false; this->mFactoryTickFunction.bCanEverTick = false; this->mFactoryTickFunction.bStartWithTickEnabled = true; this->mFactoryTickFunction.bAllowTickOnDedicatedServer = true; this->mFactoryTickFunction.TickInterval = 0;

--- a/Source/FactoryGame/Private/FGRecipe.cpp
+++ b/Source/FactoryGame/Private/FGRecipe.cpp
@@ -4,7 +4,8 @@
 
 #if WITH_EDITOR
 void UFGRecipe::SetProduct(TSubclassOf< UFGRecipe > recipe, TArray< FItemAmount > product){ 
-	recipe.GetDefaultObject()->mProduct = product;
+	if(recipe)
+		recipe.GetDefaultObject()->mProduct = product;
 }
 #endif 
 UFGRecipe::UFGRecipe() : Super() {
@@ -12,29 +13,48 @@ UFGRecipe::UFGRecipe() : Super() {
 	this->mManualManufacturingMultiplier = 1;
 }
 FText UFGRecipe::GetRecipeName(TSubclassOf< UFGRecipe > inClass){ 
-	return inClass.GetDefaultObject()->mDisplayName;
+	if (inClass)
+		return inClass.GetDefaultObject()->mDisplayName;
+	else
+		return FText();
 }
 TArray< FItemAmount > UFGRecipe::GetIngredients(TSubclassOf< UFGRecipe > inClass){ 
-	return inClass.GetDefaultObject()->mIngredients;
+	if (inClass)
+		return inClass.GetDefaultObject()->mIngredients;
+	else
+		return TArray<FItemAmount>();
 }
 TArray< FItemAmount > UFGRecipe::GetProducts(TSubclassOf< UFGRecipe > inClass, bool allowChildRecipes){ 
-	return inClass.GetDefaultObject()->mProduct;
+	if (inClass)
+		return inClass.GetDefaultObject()->mProduct;
+	else
+		return TArray< FItemAmount >();
 }
 float UFGRecipe::GetManufacturingDuration(TSubclassOf< UFGRecipe > inClass){ 
-	return inClass.GetDefaultObject()->mManufactoringDuration;
+	if (inClass)
+		return inClass.GetDefaultObject()->mManufactoringDuration;
+	else
+		return float();
 }
 float UFGRecipe::GetManualManufacturingDuration(TSubclassOf< UFGRecipe > inClass){ 
-	return inClass.GetDefaultObject()->mManualManufacturingMultiplier;
+	if (inClass)
+		return inClass.GetDefaultObject()->mManualManufacturingMultiplier;
+	else
+		return float();
 }
 TArray< TSubclassOf< UObject > > UFGRecipe::GetProducedIn(TSubclassOf< UFGRecipe > inClass){ 
 	TArray<TSubclassOf<UObject>>   out;
+	if (!inClass)
+		return TArray< TSubclassOf< UObject > >();
+	
 	TArray<TSoftClassPtr<UObject>> In = inClass.GetDefaultObject()->mProducedIn;
 	if (In.Num() > 0)
 	{
 		for (int j = 0; j < In.Num(); j++)
 		{
 			TSubclassOf<UObject> obj = In[j].LoadSynchronous();
-			out.Add(obj);
+			if(obj)
+				out.Add(obj);
 		}
 		return out;
 	}

--- a/Source/FactoryGame/Private/FGSchematic.cpp
+++ b/Source/FactoryGame/Private/FGSchematic.cpp
@@ -19,31 +19,56 @@ UFGSchematic::UFGSchematic() : Super() {
 	this->mTimeToComplete = 600;
 }
 ESchematicType UFGSchematic::GetType(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mType;
+	if (inClass)
+		return inClass.GetDefaultObject()->mType;
+	else
+		return ESchematicType();
 }
 FText UFGSchematic::GetSchematicDisplayName(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mDisplayName;
+	if (inClass)
+		return inClass.GetDefaultObject()->mDisplayName;
+	else
+		return FText();
 }
 TSubclassOf< class UFGSchematicCategory > UFGSchematic::GetSchematicCategory(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mSchematicCategory;
+	if (inClass)
+		return inClass.GetDefaultObject()->mSchematicCategory;
+	else
+		return TSubclassOf< class UFGSchematicCategory >();
 }
 void UFGSchematic::GetSubCategories(TSubclassOf< UFGSchematic > inClass,  TArray< TSubclassOf<  UFGSchematicCategory > >& out_subCategories){ 
-	out_subCategories = inClass.GetDefaultObject()->mSubCategories;
+	if(inClass)
+		out_subCategories = inClass.GetDefaultObject()->mSubCategories;
 }
 TArray< FItemAmount > UFGSchematic::GetCost(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mCost;
+	if (inClass)
+		return inClass.GetDefaultObject()->mCost;
+	else
+		return TArray< FItemAmount >();
 }
 TArray< UFGUnlock* > UFGSchematic::GetUnlocks(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mUnlocks;
+	if (inClass)
+		return inClass.GetDefaultObject()->mUnlocks;
+	else
+		return TArray<UFGUnlock*>();
 }
 int32 UFGSchematic::GetTechTier(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mTechTier;
+	if (inClass)
+		return inClass.GetDefaultObject()->mTechTier;
+	else
+		return int32();
 }
 float UFGSchematic::GetTimeToComplete(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mTimeToComplete;
+	if (inClass)
+		return inClass.GetDefaultObject()->mTimeToComplete;
+	else
+		return float();
 }
 FSlateBrush UFGSchematic::GetItemIcon(TSubclassOf< UFGSchematic > inClass){ 
-	return inClass.GetDefaultObject()->mSchematicIcon;
+	if (inClass)
+		return inClass.GetDefaultObject()->mSchematicIcon;
+	else
+		return FSlateBrush();
 }
 bool UFGSchematic::AreSchematicDependenciesMet(TSubclassOf< UFGSchematic > inClass, UObject* worldContext){ return bool(); }
 void UFGSchematic::GetSchematicDependencies(TSubclassOf< UFGSchematic > inClass, TArray<  UFGAvailabilityDependency* >& out_schematicDependencies){ }

--- a/Source/FactoryGame/Private/Resources/FGItemDescriptor.cpp
+++ b/Source/FactoryGame/Private/Resources/FGItemDescriptor.cpp
@@ -37,75 +37,198 @@ UFGItemDescriptor::UFGItemDescriptor() : Super() {
 void UFGItemDescriptor::Serialize(FArchive& ar){ Super::Serialize(ar); }
 void UFGItemDescriptor::PostLoad(){ Super::PostLoad(); }
 EResourceForm UFGItemDescriptor::GetForm(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mForm;
+	if (inClass)
+		return inClass.GetDefaultObject()->mForm;
+	else
+		return EResourceForm();
 }
 float UFGItemDescriptor::GetEnergyValue(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mEnergyValue;
+	if (inClass)
+		return inClass.GetDefaultObject()->mEnergyValue;
+	else
+		return float();
 }
 float UFGItemDescriptor::GetRadioactiveDecay(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mRadioactiveDecay;
+	if (inClass)
+		return inClass.GetDefaultObject()->mRadioactiveDecay;
+	else
+		return float();
 }
 FText UFGItemDescriptor::GetItemName(TSubclassOf< UFGItemDescriptor > inClass){ 
-	if (inClass.GetDefaultObject()->mUseDisplayNameAndDescription == true)
-	return inClass.GetDefaultObject()->mDisplayName;
-else
-	return FText::FromString(inClass->GetName());
+	if (!inClass)
+		return FText();
+	if (inClass.GetDefaultObject()->mUseDisplayNameAndDescription)
+		return inClass.GetDefaultObject()->mDisplayName;
+	else
+		return FText::FromString(inClass->GetName());
 }
 FText UFGItemDescriptor::GetItemDescription(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mDescription;
+	if (inClass)
+		return inClass.GetDefaultObject()->mDescription;
+	else
+		return FText();
 }
 FText UFGItemDescriptor::GetAbbreviatedDisplayName(TSubclassOf< UFGItemDescriptor > inClass){ return FText(); }
 void UFGItemDescriptor::GetPreviewView(TSubclassOf< UFGItemDescriptor > inClass, FItemView& out_previewView){ }
 void UFGItemDescriptor::GetIconView(TSubclassOf< UFGItemDescriptor > inClass, FItemView& out_itemView){ }
 FSlateBrush UFGItemDescriptor::GetItemIcon(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mInventoryIcon;
+	if (inClass)
+		return inClass.GetDefaultObject()->mInventoryIcon;
+	else
+		return FSlateBrush();
 }
 UTexture2D* UFGItemDescriptor::GetSmallIcon(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mSmallIcon;
+	if (inClass)
+		return inClass.GetDefaultObject()->mSmallIcon;
+	else
+		return nullptr;
 }
 UTexture2D* UFGItemDescriptor::GetBigIcon(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mPersistentBigIcon;
+	if (inClass)
+		return inClass.GetDefaultObject()->mPersistentBigIcon;
+	else
+		return nullptr;
 }
 UStaticMesh* UFGItemDescriptor::GetItemMesh(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mConveyorMesh;
+	if (inClass)
+		return inClass.GetDefaultObject()->mConveyorMesh;
+	else
+		return nullptr;
 }
 int32 UFGItemDescriptor::GetStackSize(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return static_cast<int32>(inClass.GetDefaultObject()->mStackSize);
+	if (inClass)
+		return static_cast<int32>(inClass.GetDefaultObject()->mStackSize);
+	else
+		return int32();
 }
 float UFGItemDescriptor::GetStackSizeConverted(TSubclassOf< UFGItemDescriptor > inClass){ return float(); }
 bool UFGItemDescriptor::CanBeDiscarded(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mCanBeDiscarded;
+	if (inClass)
+		return inClass.GetDefaultObject()->mCanBeDiscarded;
+	else
+		return bool();
 }
 bool UFGItemDescriptor::RememberPickUp(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mRememberPickUp;
+	if (inClass)
+		return inClass.GetDefaultObject()->mRememberPickUp;
+	else
+		return bool();
 }
 TSubclassOf< UFGItemCategory > UFGItemDescriptor::GetItemCategory(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mItemCategory;
+	if (inClass)
+		return inClass.GetDefaultObject()->mItemCategory;
+	else
+		return TSubclassOf< UFGItemCategory >();
 }
 float UFGItemDescriptor::GetFluidDensity(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mFluidDensity;
+	if (inClass)
+		return inClass.GetDefaultObject()->mFluidDensity;
+	else
+		return float();
 }
 float UFGItemDescriptor::GetFluidViscosity(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mFluidViscosity;
+	if (inClass)
+		return inClass.GetDefaultObject()->mFluidViscosity;
+	else
+		return float();
 }
 float UFGItemDescriptor::GetFluidFriction(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mFluidFriction;
+	if (inClass)
+		return inClass.GetDefaultObject()->mFluidFriction;
+	else
+		return float();
 }
 FColor UFGItemDescriptor::GetFluidColor(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mFluidColor;
+	if (inClass)
+		return inClass.GetDefaultObject()->mFluidColor;
+	else
+		return FColor();
 }
 FLinearColor UFGItemDescriptor::GetFluidColorLinear(TSubclassOf< UFGItemDescriptor > inClass){ 
-	return inClass.GetDefaultObject()->mFluidColor.ReinterpretAsLinear();
+	if (inClass)
+		return inClass.GetDefaultObject()->mFluidColor.ReinterpretAsLinear();
+	else
+		return FLinearColor();
 }
-FTransform UFGItemDescriptor::GetIconCameraTransform(TSubclassOf< UFGItemDescriptor > inClass){ return FTransform(); }
-void UFGItemDescriptor::SetIconCameraTransform(TSubclassOf< UFGItemDescriptor > inClass, FTransform cameraTransform){ }
-float UFGItemDescriptor::GetIconFOV(TSubclassOf< UFGItemDescriptor > inClass){ return float(); }
-void UFGItemDescriptor::SetIconFOV(TSubclassOf< UFGItemDescriptor > inClass, float iconFOV){ }
-FRotator UFGItemDescriptor::GetIconObjectOrientation(TSubclassOf< UFGItemDescriptor > inClass){ return FRotator(); }
-void UFGItemDescriptor::SetIconObjectOrientation(TSubclassOf< UFGItemDescriptor > inClass, FRotator objectOrientation){ }
-float UFGItemDescriptor::GetIconCameraDistance(TSubclassOf< UFGItemDescriptor > inClass){ return float(); }
-void UFGItemDescriptor::SetIconCameraDistance(TSubclassOf< UFGItemDescriptor > inClass, float cameraDistance){ }
-FRotator UFGItemDescriptor::GetIconSkyOrientation(TSubclassOf< UFGItemDescriptor > inClass){ return FRotator(); }
-void UFGItemDescriptor::SetIconSkyOrientation(TSubclassOf< UFGItemDescriptor > inClass, FRotator skyOrientation){ }
+FTransform UFGItemDescriptor::GetIconCameraTransform(TSubclassOf< UFGItemDescriptor > inClass){ 
+	if (inClass)
+#if WITH_EDITOR
+		return inClass.GetDefaultObject()->mIconCameraTransform;
+#else
+		return FTransform();
+#endif
+	else
+		return FTransform(); 
+}
+void UFGItemDescriptor::SetIconCameraTransform(TSubclassOf< UFGItemDescriptor > inClass, FTransform cameraTransform){
+#if WITH_EDITOR
+	if (inClass)
+		inClass.GetDefaultObject()->mIconCameraTransform = cameraTransform;
+#endif
+}
+float UFGItemDescriptor::GetIconFOV(TSubclassOf< UFGItemDescriptor > inClass){ 
+	if (inClass)
+#if WITH_EDITOR
+		return inClass.GetDefaultObject()->mIconFOV;
+#else
+		return float();
+#endif
+	else
+		return float();
+}
+void UFGItemDescriptor::SetIconFOV(TSubclassOf< UFGItemDescriptor > inClass, float iconFOV){
+#if WITH_EDITOR
+	if (inClass)
+		inClass.GetDefaultObject()->mIconFOV = iconFOV;
+#endif
+}
+FRotator UFGItemDescriptor::GetIconObjectOrientation(TSubclassOf< UFGItemDescriptor > inClass){ 
+	if (inClass)
+#if WITH_EDITOR
+		return inClass.GetDefaultObject()->mIconObjectOrientation;
+#else
+		return FRotator();
+#endif
+	else
+		return FRotator(); 
+}
+void UFGItemDescriptor::SetIconObjectOrientation(TSubclassOf< UFGItemDescriptor > inClass, FRotator objectOrientation){
+#if WITH_EDITOR
+	if (inClass)
+		inClass.GetDefaultObject()->mIconObjectOrientation = objectOrientation;
+#endif
+}
+float UFGItemDescriptor::GetIconCameraDistance(TSubclassOf< UFGItemDescriptor > inClass){
+	if (inClass)
+#if WITH_EDITOR
+		return inClass.GetDefaultObject()->mIconCameraDistance;
+#else
+		return float();
+#endif
+	else
+		return  float(); 
+}
+void UFGItemDescriptor::SetIconCameraDistance(TSubclassOf< UFGItemDescriptor > inClass, float cameraDistance){ 
+#if WITH_EDITOR
+	if (inClass)
+		inClass.GetDefaultObject()->mIconCameraDistance = cameraDistance;
+#endif
+}
+FRotator UFGItemDescriptor::GetIconSkyOrientation(TSubclassOf< UFGItemDescriptor > inClass){
+	if (inClass)
+#if WITH_EDITOR
+		return inClass.GetDefaultObject()->mIconSkyOrientation;
+#else
+		return FRotator();
+#endif
+	else
+		return FRotator(); 
+}
+void UFGItemDescriptor::SetIconSkyOrientation(TSubclassOf< UFGItemDescriptor > inClass, FRotator skyOrientation){
+#if WITH_EDITOR
+	if (inClass)
+		inClass.GetDefaultObject()->mIconSkyOrientation = skyOrientation;
+#endif
+}
 FText UFGItemDescriptor::GetItemNameInternal() const{ return FText(); }
 FText UFGItemDescriptor::GetItemDescriptionInternal() const{ return FText(); }

--- a/Source/FactoryGame/Public/FGPipeConnectionComponent.h
+++ b/Source/FactoryGame/Public/FGPipeConnectionComponent.h
@@ -260,10 +260,11 @@ private:
 	*/
 	UFUNCTION()
 	void OnRep_FluidDescriptor();
-
-protected:
+//MODDING EDIT protected -> public
+public:
 	/** The inventory of this connection. This can be null in many cases. */
-	UPROPERTY( SaveGame )
+	// MODDING EDIT VERY Experimental most buildings handle this on their own. Writing to it maybe crashes. 
+	UPROPERTY(BlueprintReadWrite, SaveGame )
 	class UFGInventoryComponent* mConnectionInventory;
 
 	/**
@@ -272,14 +273,16 @@ protected:
 	 * buildables. This is because fluids should belong to a single stack in an inventory and if none is specified then a pipe should
 	 * not be eligible to receive liquid. There may be a better way to handle this but that is how its operating.
 	 */
-	UPROPERTY( SaveGame )
+	//MODDING EDIT Experimental !!! Writing to it maybe crashes
+	UPROPERTY(BlueprintReadWrite, SaveGame )
 	int32 mInventoryAccessIndex;
 
 	/**
 	 * The network this connection is connected to. INDEX_NONE if not connected.
 	 * @note - This ID may change at any time when changes occurs in the network. Do not save copies of it!
 	 */
-	UPROPERTY( SaveGame, VisibleAnywhere, Replicated, Category = "Connection" )
+	//MODDING EDIT added BlueprintReadOnly
+	UPROPERTY( SaveGame, BlueprintReadOnly, VisibleAnywhere, Replicated, Category = "Connection" )
 	int32 mPipeNetworkID;
 
 	/**
@@ -290,8 +293,7 @@ protected:
 	//           We cannot do that on the client cause it does not have a graph built.
 	//           And the pipe network id gets wonky on the client as well... and
 	//           we need this to work for the play test so for now lets go with ugly.
-	// MODDING EDIT : protected -> public + BPReadyOnly and Visibiltiy
-	public:
+	// MODDING EDIT : BPReadyOnly and Visibiltiy  -- End protected->public
 	UPROPERTY(BlueprintReadOnly,VisibleAnywhere, ReplicatedUsing = OnRep_FluidDescriptor )
 	TSubclassOf< class UFGItemDescriptor > mFluidDescriptor;
 	protected:

--- a/Source/FactoryGame/Public/Resources/FGResourceNode.h
+++ b/Source/FactoryGame/Public/Resources/FGResourceNode.h
@@ -248,17 +248,18 @@ protected:
 	/** Called when a resource is extracted. Never called on infinite resource nodes. */
 	virtual void UpdateRadioactivity();
 
-protected:
+public: // MODDING EDIT protected -> public
 	/** Type of resource */
-	UPROPERTY( EditAnywhere, Category = "Resources" )
+	//MODDING EDIT BlueprintReadOnly.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Resources" )
 	TSubclassOf<UFGResourceDescriptor> mResourceClass;
 
 	/** How pure the resource is */
-	UPROPERTY(EditInstanceOnly, Category= "Resources" )
+	UPROPERTY(EditInstanceOnly,BlueprintReadWrite, Category= "Resources" )
 	TEnumAsByte<EResourcePurity> mPurity;
 
 	/** How pure the resource is */
-	UPROPERTY( EditInstanceOnly, Category = "Resources" )
+	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category = "Resources" )
 	TEnumAsByte<EResourceAmount> mAmount;
 
 	/** the decal that used for displaying the resource */
@@ -269,12 +270,12 @@ protected:
 	UPROPERTY( BlueprintReadOnly, VisibleDefaultsOnly, Category = "Resources" )
 	UBoxComponent* mBoxComponent;
 
-public: // MODDING EDIT
+
 	/** How much resources is left in this node */
 	UPROPERTY( SaveGame, Replicated, BlueprintReadWrite, Category="Resources")
 	int32 mResourcesLeft;
 
-protected: // MODDING EDIT
+protected: // MODDING EDIT ^ protected 
 	/** If true, then we are occupied by something // [Dylan 3/2/2020] - Removed savegame meta */
 	UPROPERTY( ReplicatedUsing = OnRep_IsOccupied, BlueprintReadOnly, Category = "Resources" )
 	bool mIsOccupied;

--- a/Source/SML/mod/BlueprintLibrary.cpp
+++ b/Source/SML/mod/BlueprintLibrary.cpp
@@ -116,6 +116,9 @@ FString USMLBlueprintLibrary::GetBootstrapperVersion() {
 	return SML::getBootstrapperVersion().string();
 }
 
+bool USMLBlueprintLibrary::GetDevelopmentModeEnabled() {
+	return SML::getSMLConfig().developmentMode;
+}
 
 void USMLBlueprintLibrary::InternalGetStructAsJson(UStructProperty *Structure, void* StructurePtr, FString &String, bool UsePretty)
 {

--- a/Source/SML/mod/BlueprintLibrary.h
+++ b/Source/SML/mod/BlueprintLibrary.h
@@ -57,6 +57,14 @@ public:
 	static FString GetBootstrapperVersion();
 
 	/**
+	 * Returns the currently used DevelopmentMode Setting
+	 */
+	UFUNCTION(BlueprintCallable, Category = "SML")
+		static bool GetDevelopmentModeEnabled();
+
+
+
+	/**
 	 * Saves the given struct as config file for the given modid
 	 * @param modid - the modid you want to save to config for
 	 * @param Config - the struct you want to save as config


### PR DESCRIPTION
Commented mInstancedSplineComponent in the constructor AFGBuildablePipeBase out, it crashes the game on startup.
Added inClass nullptr checks in FGSchematic, FGRecipe and FGItemDescriptor to prevent the editor from crashing when one is provided.
Added function bodies for EDITOR ONLY Icon values on FGItemDescriptor.
PipeConnection Inventory variables set to BPReadOnly/BPReadWrite.
ResourceNode protected variables set to BPReadOnly/BPReadWrite.
Added BP Function to get the currently used DevelopmentModeSetting.