### PR TITLE
Work around for Remote Client crash on player join

### DIFF
--- a/Source/SML/mod/ModHandler.cpp
+++ b/Source/SML/mod/ModHandler.cpp
@@ -244,7 +244,9 @@ void FModHandler::PostInitializeModActors() {
 }
 
 void FModHandler::HandlePlayerJoin(AFGPlayerController* PlayerController) {
-	SML::Logging::info(TEXT("HandlePlayerJoin "), *PlayerController->PlayerState->GetPlayerName());
+	if (PlayerController->PlayerState != nullptr) {
+		SML::Logging::info(TEXT("HandlePlayerJoin "), *PlayerController->PlayerState->GetPlayerName());
+	}
 	for (const TWeakObjectPtr<AActor>& Actor : this->ModInitializerActorList) {
 		if (Actor->IsValidLowLevel()) {
 			if (ASMLInitMod* InitMod = Cast<ASMLInitMod>(Actor)) {


### PR DESCRIPTION
Temporary work around for Remote Client crash from SML::Mod::FModHandler::handlePlayerJoin() calling APlayerState::GetPlayerName() when PlayerState is null.

While this doesn't resolve the PlayerState being null, it stops clients crashing on join. Testing shows no issues so far.