### PR TITLE
Disabled SteamVR plugin and added alpakit settings for copying dll and pdb files to game directory

### DIFF
--- a/FactoryGame.uproject
+++ b/FactoryGame.uproject
@@ -44,6 +44,10 @@
 		{
 			"Name": "Alpakit",
 			"Enabled": true
+		},
+		{
+			"Name": "SteamVR",
+			"Enabled": false
 		}
 	]
 }

--- a/Plugins/Alpakit/Source/Alpakit/Private/AlpakitWidget.cpp
+++ b/Plugins/Alpakit/Source/Alpakit/Private/AlpakitWidget.cpp
@@ -278,6 +278,34 @@ void SAlpakaWidget::CookDone(FString result, double runtime,UAlpakitSettings* Se
 				// Copy to Satisfactory mods folder
 				PlatformFile.CopyFile(*(gameModsDir / FString::Printf(TEXT("%s.pak"), *pakName)), *pakFilePath);
 				UE_LOG(LogTemp, Log, TEXT("Copied %s to game dir"), *mod.Name);
+
+				if (Settings->CopyDllsToGame) {
+					FString modFileNameWithoutExtension = FString::Printf(TEXT("UE4-%s-Win64-Shipping"), *mod.Name);
+					FString buildDirectory = FPaths::ConvertRelativePathToFull(FPaths::ProjectDir(), FString(TEXT("Binaries/Win64")));
+					FString dllPath = FPaths::Combine(*buildDirectory, *modFileNameWithoutExtension);
+					dllPath = FPaths::SetExtension(dllPath, FString(TEXT(".dll")));
+
+					if (!FPaths::FileExists(dllPath)) {
+						UE_LOG(LogTemp, Error, TEXT("Did not copy mod dll to game, file not found: %s"), *dllPath);
+					}
+					else {
+						PlatformFile.CopyFile(*(gameModsDir / FString::Printf(TEXT("%s.dll"), *modFileNameWithoutExtension)), *dllPath);
+						UE_LOG(LogTemp, Log, TEXT("Copied %s to game dir"), *FPaths::GetCleanFilename(dllPath));
+					}
+
+					if (Settings->CopyDebugSymbolsToGame) {
+						FString pdbPath = FPaths::Combine(*buildDirectory, *modFileNameWithoutExtension);
+						pdbPath = FPaths::SetExtension(pdbPath, FString(TEXT(".pdb")));
+
+						if (!FPaths::FileExists(pdbPath)) {
+							UE_LOG(LogTemp, Error, TEXT("Did not copy mod pdb to game, file not found: %s"), *dllPath);
+						}
+						else {
+							PlatformFile.CopyFile(*(gameModsDir / FString::Printf(TEXT("%s.pdb"), *modFileNameWithoutExtension)), *pdbPath);
+							UE_LOG(LogTemp, Log, TEXT("Copied %s to game dir"), *FPaths::GetCleanFilename(pdbPath));
+						}
+					}
+				}
 			}
 		}
 		if (Settings->CopyModsToGame && modsCopied > 0) {

--- a/Plugins/Alpakit/Source/Alpakit/Private/AlpakitWidget.cpp
+++ b/Plugins/Alpakit/Source/Alpakit/Private/AlpakitWidget.cpp
@@ -286,7 +286,7 @@ void SAlpakaWidget::CookDone(FString result, double runtime,UAlpakitSettings* Se
 					dllPath = FPaths::SetExtension(dllPath, FString(TEXT(".dll")));
 
 					if (!FPaths::FileExists(dllPath)) {
-						UE_LOG(LogTemp, Error, TEXT("Did not copy mod dll to game, file not found: %s"), *dllPath);
+						UE_LOG(LogTemp, Warning, TEXT("Did not copy mod dll to game, file not found: %s. This may not be a problem if this mod does not have a custom module."), *dllPath);
 					}
 					else {
 						PlatformFile.CopyFile(*(gameModsDir / FString::Printf(TEXT("%s.dll"), *modFileNameWithoutExtension)), *dllPath);
@@ -298,7 +298,7 @@ void SAlpakaWidget::CookDone(FString result, double runtime,UAlpakitSettings* Se
 						pdbPath = FPaths::SetExtension(pdbPath, FString(TEXT(".pdb")));
 
 						if (!FPaths::FileExists(pdbPath)) {
-							UE_LOG(LogTemp, Error, TEXT("Did not copy mod pdb to game, file not found: %s"), *dllPath);
+							UE_LOG(LogTemp, Warning, TEXT("Did not copy mod pdb to game, file not found: %s. This may not be a problem if this mod does not have a custom module."), *dllPath);
 						}
 						else {
 							PlatformFile.CopyFile(*(gameModsDir / FString::Printf(TEXT("%s.pdb"), *modFileNameWithoutExtension)), *pdbPath);

--- a/Plugins/Alpakit/Source/Alpakit/Public/AlpakitSettings.h
+++ b/Plugins/Alpakit/Source/Alpakit/Public/AlpakitSettings.h
@@ -54,9 +54,16 @@ public:
 	TArray<FAlpakitMod> Mods;
 
 	UPROPERTY(EditAnywhere, config, Category = Config)
-	bool StartGame;
-
-	UPROPERTY(EditAnywhere, config, Category = Config)
 	bool CopyModsToGame;
 
+	/** If enabled the shipping dll files will be copied to the game if found. This is required if your mod has a custom module. */
+	UPROPERTY(EditAnywhere, config, Category = Config, meta = (EditCondition = "CopyModsToGame"))
+	bool CopyDllsToGame;
+
+	/** If enabled the .pdb files for the shipping dll files will be copied to the game if found. The game's crash reporter will then be able to show more accurate crash stack traces. */
+	UPROPERTY(EditAnywhere, config, Category = Config, meta = (EditCondition = "CopyDllsToGame"))
+	bool CopyDebugSymbolsToGame;
+
+	UPROPERTY(EditAnywhere, config, Category = Config)
+	bool StartGame;
 };


### PR DESCRIPTION
The reason for disabling SteamVR is because it redirects your sound input everytime you launch the editor if you have it configured that way. Since the game doesn't have VR support there's no reason this plugin should be enabled by default.

The alpakit settings are pretty self-explanatory.