### PR TITLE
 Allow hooking to const methods [#55] 

### DIFF
--- a/Source/SML/mod/ModHandler.cpp
+++ b/Source/SML/mod/ModHandler.cpp
@@ -150,7 +150,7 @@ void FModHandler::AttachLoadingHooks() {
 	SUBSCRIBE_METHOD_AFTER(AFGGameState::Init, [](AFGGameState* GameState) {
 		SML::GetModHandler().PreInitializeModActors();
 		SML::Logging::info(TEXT("Finished pre-subsystem-initializing mod actors"));
-	});
+	}); 
 	
 	SUBSCRIBE_METHOD( AGameState::ReceivedGameModeClass, [](auto&, AGameStateBase* gameMode) {
 		UWorld* World = gameMode->GetWorld();

--- a/Source/SML/player/OfflinePlayHandler.cpp
+++ b/Source/SML/player/OfflinePlayHandler.cpp
@@ -3,33 +3,28 @@
 #include "mod/hooking.h"
 #include "util/Logging.h"
 
-class IFuckingHateConstMethods {
-public:
-    FString* ShittyMethod(FString* OutReturnValue) { return nullptr; }
-    FUniqueNetIdRepl* ShittyMethod2(FUniqueNetIdRepl* OutUniqueNetIdRepl) { return nullptr; }
-};
 
 extern void GRegisterOfflinePlayHandler() {
     FString UsernameOverride = TEXT("");
     FParse::Value(FCommandLine::Get(), TEXT("-Username="), UsernameOverride);
+
     if (!UsernameOverride.IsEmpty()) {
         SML::Logging::info(TEXT("Offline Username Override: "), *UsernameOverride);
-        SUBSCRIBE_METHOD_MANUAL("ULocalPlayer::GetNickname", IFuckingHateConstMethods::ShittyMethod, [=](auto& Call, auto* Player, FString* OutReturnValue) {
-            FString* ReturnedParentValue = Call(Player, OutReturnValue);
-            if (ReturnedParentValue->IsEmpty()) {
+        SUBSCRIBE_METHOD(ULocalPlayer::GetNickname, [=](auto& Call, ULocalPlayer* Player) {
+            FString ReturnedParentValue = Call(Player);
+            if (ReturnedParentValue.IsEmpty()) {
                 SML::Logging::info(TEXT("Online Subsystem Nickname not provided, falling back to -Username"));
-                *OutReturnValue = UsernameOverride;
-                Call.Override(OutReturnValue);
+                Call.Override(UsernameOverride);
             }
-            SML::Logging::info(TEXT("Parent GetNickname: "), **ReturnedParentValue);
+            SML::Logging::info(TEXT("Parent GetNickname: "), *ReturnedParentValue);
         });
-        SUBSCRIBE_METHOD_MANUAL("ULocalPlayer::GetUniqueNetIdFromCachedControllerId", IFuckingHateConstMethods::ShittyMethod2, [=](auto& Call, auto* Player, FUniqueNetIdRepl* OutReturnValue) {
-            FUniqueNetIdRepl* ReturnedParentValue = Call(Player, OutReturnValue);
-            if (!ReturnedParentValue->IsValid()) {
+
+        SUBSCRIBE_METHOD(ULocalPlayer::GetUniqueNetIdFromCachedControllerId, [=](auto& Call, ULocalPlayer* Player) {
+            FUniqueNetIdRepl ReturnedParentValue = Call(Player);
+            if (!ReturnedParentValue.IsValid()) {
                 SML::Logging::info(TEXT("Online Subsystem UniqueNotId not provided, falling back to -Username-generated UniqueId"));
                 const TSharedPtr<const FUniqueNetId> UniqueNetIdPtr = UOnlineEngineInterface::Get()->CreateUniquePlayerId(UsernameOverride);
-                *OutReturnValue = FUniqueNetIdRepl(UniqueNetIdPtr);
-                Call.Override(OutReturnValue);
+                Call.Override(FUniqueNetIdRepl(UniqueNetIdPtr));
             }
         });
     }


### PR DESCRIPTION
Allow hooking to const methods by removing the constness of the method which allows us to reuse the current code without duplication as it was suggested in #55.

Given #56 & #55 are fixed, I updated `OfflinePlayHandler.cpp` to not use the dummy methods, it also used as test case for this MR.