### PR TITLE
Fix SML logging not printing to the console

### DIFF
--- a/Source/SML/util/Console.cpp
+++ b/Source/SML/util/Console.cpp
@@ -20,10 +20,26 @@ void SML::EnableConsole() {
 	SML::Logging::info(TEXT("Enabling Console Window..."));
 	AllocConsole();
 	ShowWindow(GetConsoleWindow(), SW_SHOW);
+	
 	FILE* fp;
-	freopen_s(&fp, "CONOIN$", "r", stdin);
 	freopen_s(&fp, "CONOUT$", "w", stdout);
 	freopen_s(&fp, "CONOUT$", "w", stderr);
+	freopen_s(&fp, "CONOIN$", "r", stdin);
+	std::cout.clear();
+	std::clog.clear();
+	std::cerr.clear();
+	std::cin.clear();
+	
+	HANDLE hConOut = CreateFile(_T("CONOUT$"), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	HANDLE hConIn = CreateFile(_T("CONIN$"), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	SetStdHandle(STD_OUTPUT_HANDLE, hConOut);
+	SetStdHandle(STD_ERROR_HANDLE, hConOut);
+	SetStdHandle(STD_INPUT_HANDLE, hConIn);
+	std::wcout.clear();
+	std::wclog.clear();
+	std::wcerr.clear();
+	std::wcin.clear();
+	
 	SML::Logging::info(TEXT("Console Window enabled!"));
 }
 #else


### PR DESCRIPTION
SML was setup to log to wcout but the console was not setup to pipe wcout to it. This uses https://stackoverflow.com/a/57241985/5645559 to bring back SML logging to the console.

![image](https://user-images.githubusercontent.com/1206980/95416334-10b2d880-08f8-11eb-8a92-78a248bf0855.png)
