### PR TITLE
store ModuleManager on World instead of on GameState

### DIFF
--- a/Plugins/SML/Source/SML/Private/Module/WorldModuleManager.cpp
+++ b/Plugins/SML/Source/SML/Private/Module/WorldModuleManager.cpp
@@ -11,13 +11,12 @@
 
 AWorldModuleManager* AWorldModuleManager::Get(UObject* WorldContext) {
     UWorld* World = GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::Assert);
-    AGameStateBase* GameState = World->GetGameState();
-    check(GameState);
-    UWorldModuleManagerComponent* ModuleManagerComponent = GameState->FindComponentByClass<UWorldModuleManagerComponent>();
+    check(World);
     
+    UWorldModuleManagerComponent* ModuleManagerComponent = FindObject<UWorldModuleManagerComponent>(World, TEXT("WorldModuleManagerComponent"));
     if (ModuleManagerComponent == NULL) {
         //World Module Manager has not been initialized yet, perform lazy initialization
-        ModuleManagerComponent = NewObject<UWorldModuleManagerComponent>(GameState, TEXT("WorldModuleManagerComponent"));
+        ModuleManagerComponent = NewObject<UWorldModuleManagerComponent>(World, TEXT("WorldModuleManagerComponent"));
         check(ModuleManagerComponent);
         ModuleManagerComponent->SpawnModuleManager();
         ModuleManagerComponent->RegisterComponent();


### PR DESCRIPTION
Appears to fix client crashing on joining a MP session. 

I'm a UE4 noob so there may be some more-appropriate delegate to use, and this is admittedly hacky but I thought I'd PR it just in case it helps point towards an MP fix sooner :)