### PR TITLE
Fix compile issue if mItemCategory is used

### DIFF
--- a/Source/FactoryGame/Public/Resources/FGItemDescriptor.h
+++ b/Source/FactoryGame/Public/Resources/FGItemDescriptor.h
@@ -4,6 +4,7 @@
 
 #include "UObject/Object.h"
 #include "Styling/SlateBrush.h"
+#include "FGItemCategory.h"
 #include "FGItemDescriptor.generated.h"
 
 /**


### PR DESCRIPTION
(missing include)

for Example

auto RecipeClassDefault = (UFGRecipe*)RecipeClass->GetDefaultObject();
RecipeClassDefault->mOverriddenCategory