### PR TITLE
Update DefaultEngine.ini to add Vulkan target

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -286,3 +286,10 @@ PhysXTreeRebuildRate=50
 +PhysicalSurfaces=(Type=SurfaceType14,Name="Surface_Panel")
 +PhysicalSurfaces=(Type=SurfaceType15,Name="Surface_Tree")
 DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,MBPBounds=(Min=(X=0.000000,Y=0.000000,Z=0.000000),Max=(X=0.000000,Y=0.000000,Z=0.000000),IsValid=0),MBPNumSubdivs=2)
+
+[/Script/WindowsTargetPlatform.WindowsTargetSettings]
+Compiler=Default
+-TargetedRHIs=PCD3D_SM5
++TargetedRHIs=PCD3D_SM5
++TargetedRHIs=SF_VULKAN_SM5
+DefaultGraphicsRHI=DefaultGraphicsRHI_Default


### PR DESCRIPTION
Vulkan needs to be added to the Windows Target List or shaders won't be cooked for it, causing materials and textures to fallback to defaults.