### PR TITLE
Add Mod Config Updated Delegate and Broadcast

### DIFF
--- a/Plugins/SML/Source/SML/Private/Configuration/ConfigManager.cpp
+++ b/Plugins/SML/Source/SML/Private/Configuration/ConfigManager.cpp
@@ -57,6 +57,7 @@ void UConfigManager::SaveConfigurationInternal(const FConfigId& ConfigId) {
         return;
     }
     UE_LOG(LogConfigManager, Display, TEXT("Saved configuration to %s"), *ConfigurationFilePath);
+    OnConfigSaved.Broadcast(ConfigId);
 }
 
 void UConfigManager::LoadConfigurationInternal(const FConfigId& ConfigId, URootConfigValueHolder* RootConfigValueHolder, bool bSaveOnSchemaChange) {

--- a/Plugins/SML/Source/SML/Public/Configuration/ConfigManager.h
+++ b/Plugins/SML/Source/SML/Public/Configuration/ConfigManager.h
@@ -12,6 +12,9 @@
 class UUserWidget;
 class URootConfigValueHolder;
 
+//Delegate for when a Mod Configuration is saved
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnConfigSaved, FConfigId, ConfigId);
+
 DECLARE_LOG_CATEGORY_EXTERN(LogConfigManager, Log, All)
 
 /** Describes active configuration data */
@@ -73,6 +76,10 @@ public:
     UFUNCTION(BlueprintPure)
     UConfigPropertySection* GetConfigurationRootSection(const FConfigId& ConfigId) const;
 
+    /** Event for when a Mod Config is saved */
+	UPROPERTY(BlueprintAssignable, Category = "Config Manager")
+    FOnConfigSaved OnConfigSaved;
+    
     void Initialize(FSubsystemCollectionBase& Collection) override;
     
     /** Returns configuration folder path used by config manager */


### PR DESCRIPTION
Added Delegate for when a mod configuration is updated. This will be useful for when a configuration property is allowed to be changed from the Pause Menu so mods can bind to the event and make any needed changes.