### PR TITLE
Prevent removal of FactoryGame Recipes and Schematics

### DIFF
--- a/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
+++ b/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
@@ -45,21 +45,21 @@ void ExtractRecipesFromSchematic(TSubclassOf<UFGSchematic> Schematic, TArray<TSu
 }
 
 void ExtractSchematicsFromResearchTree(TSubclassOf<UFGResearchTree> ResearchTree, TArray<TSubclassOf<UFGSchematic>>& OutSchematics) {
-    
+
     static FStructProperty* NodeDataStructProperty = NULL;
     static FClassProperty* SchematicStructProperty = NULL;
     static UClass* ResearchTreeNodeClass = NULL;
-    
+
     //Lazily initialize research tree node reflection properties for faster access
     if (ResearchTreeNodeClass == NULL) {
         ResearchTreeNodeClass = LoadClass<UFGResearchTreeNode>(NULL, TEXT("/Game/FactoryGame/Schematics/Research/BPD_ResearchTreeNode.BPD_ResearchTreeNode_C"));
         check(ResearchTreeNodeClass);
         //Make sure class is not garbage collected
         ResearchTreeNodeClass->AddToRoot();
-        
+
         NodeDataStructProperty = FReflectionHelper::FindPropertyChecked<FStructProperty>(ResearchTreeNodeClass, TEXT("mNodeDataStruct"));
         SchematicStructProperty = FReflectionHelper::FindPropertyByShortNameChecked<FClassProperty>(NodeDataStructProperty->Struct, TEXT("Schematic"));
-        
+
         check(SchematicStructProperty->MetaClass->IsChildOf(UFGSchematic::StaticClass()));
     }
 
@@ -87,7 +87,7 @@ template<typename T>
 TArray<TSubclassOf<T>> DiscoverVanillaContentOfType() {
     UClass* PrimaryAssetClass = T::StaticClass();
     UAssetManager& AssetManager = UAssetManager::Get();
-    
+
     const FPrimaryAssetType AssetType = PrimaryAssetClass->GetFName();
     TArray<FAssetData> FoundVanillaAssets;
     AssetManager.GetPrimaryAssetDataList(AssetType, FoundVanillaAssets);
@@ -120,12 +120,12 @@ void AModContentRegistry::DisableVanillaContentRegistration() {
 
 FName AModContentRegistry::FindContentOwnerFast(UClass* ContentClass) {
 	checkf(ContentClass, TEXT("NULL ContentClass passed to FindContentOwnerFast"));
-	
+
     //Shortcut used for quickly registering vanilla content
     if (GIsRegisteringVanillaContent) {
         return FACTORYGAME_MOD_NAME;
     }
-    
+
     //Use GetName on package instead of GetPathName() because it's faster and avoids string concat
     const FString ContentOwnerName = UBlueprintAssetHelperLibrary::FindPluginNameByObjectPath(ContentClass->GetOuterUPackage()->GetName());
     if (ContentOwnerName.IsEmpty()) {
@@ -190,11 +190,11 @@ void AModContentRegistry::Init() {
 
     //Start registering vanilla content now
     GIsRegisteringVanillaContent = true;
-    
+
     for (const TSubclassOf<UFGSchematic>& Schematic : AllSchematics) {
         RegisterSchematic(FactoryGame, Schematic);
     }
-    
+
     for (const TSubclassOf<UFGResearchTree>& ResearchTree : AllResearchTrees) {
         RegisterResearchTree(FactoryGame, ResearchTree);
     }
@@ -219,24 +219,28 @@ void AModContentRegistry::EnsureRegistryUnfrozen() const {
 
 void AModContentRegistry::CheckSavedDataForMissingObjects() {
 	checkf(bIsRegistryFrozen, TEXT("CheckSavedDataForMissingObjects called before registry is frozen"));
-	
+
     AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(this);
     AFGSchematicManager* SchematicManager = AFGSchematicManager::Get(this);
     AFGResearchManager* ResearchManager = AFGResearchManager::Get(this);
 
     TArray<FMissingObjectStruct> MissingObjects;
+    TArray<FMissingObjectStruct> UnregisteredObjects;
     if (ResearchManager != NULL) {
-        FindMissingResearchTrees(ResearchManager, MissingObjects);
+        FindMissingResearchTrees(ResearchManager, MissingObjects, UnregisteredObjects);
     }
     if (SchematicManager != NULL) {
-        FindMissingSchematics(SchematicManager, MissingObjects);
+        FindMissingSchematics(SchematicManager, MissingObjects, UnregisteredObjects);
     }
     if (RecipeManager != NULL) {
-        FindMissingRecipes(RecipeManager, MissingObjects);
+        FindMissingRecipes(RecipeManager, MissingObjects, UnregisteredObjects);
     }
 
     if (MissingObjects.Num() > 0) {
         WarnAboutMissingObjects(MissingObjects);
+    }
+    if (UnregisteredObjects.Num() > 0) {
+        WarnAboutUnregisteredObjects(UnregisteredObjects);
     }
 }
 
@@ -244,7 +248,7 @@ void AModContentRegistry::UnlockTutorialSchematics() {
 	UFGGameInstance* GameInstance = Cast<UFGGameInstance>(GetGameInstance());
 	AFGTutorialIntroManager* TutorialIntroManager = AFGTutorialIntroManager::Get(this);
 	AFGSchematicManager* SchematicManager = AFGSchematicManager::Get(this);
-	
+
 	if (SchematicManager && (GameInstance && GameInstance->GetSkipOnboarding() || TutorialIntroManager && TutorialIntroManager->GetIsTutorialCompleted())) {
 		for (const TSharedPtr<FSchematicRegistrationInfo>& RegistrationInfo : SchematicRegistryState.GetAllObjects()) {
 			const TSubclassOf<UFGSchematic> Schematic = RegistrationInfo->RegisteredObject;
@@ -278,9 +282,9 @@ void AModContentRegistry::MarkItemDescriptorsFromRecipe(const TSubclassOf<UFGRec
 
 		CHECK_PROVIDED_OBJECT_VALID(ItemDescriptor, TEXT("Recipe '%s' registered by %s contains invalid NULL ItemDescriptor in it's Ingredients or Results"),
 				*Recipe->GetPathName(), *ModReference.ToString());
-    	
+
 		TSharedPtr<FItemRegistrationInfo> ItemRegistrationInfo = ItemRegistryState.FindObject(ItemDescriptor);
-		if (!ItemRegistrationInfo.IsValid()) {        	
+		if (!ItemRegistrationInfo.IsValid()) {
 			const FName OwnerModReference = FindContentOwnerFast(ItemDescriptor);
 			ItemRegistrationInfo = RegisterItemDescriptor(OwnerModReference, ModReference, ItemDescriptor);
 		}
@@ -303,53 +307,83 @@ TSharedPtr<FItemRegistrationInfo> AModContentRegistry::RegisterItemDescriptor(co
 }
 
 void AModContentRegistry::FindMissingSchematics(AFGSchematicManager* SchematicManager,
-                                                TArray<FMissingObjectStruct>& MissingObjects) const {
+                                                TArray<FMissingObjectStruct>& MissingObjects,
+                                                TArray<FMissingObjectStruct>& UnregisteredObjects) const {
     //Clear references to unlocked schematics if they are not registered
     TArray<TSubclassOf<UFGSchematic>> PurchasedSchematics = SchematicManager->mPurchasedSchematics;
     for (const TSubclassOf<UFGSchematic> Schematic : PurchasedSchematics) {
-        if (!IsSchematicRegistered(Schematic) && !Schematic->GetPathName().StartsWith("/Game/FactoryGame")) {
-            MissingObjects.Add(FMissingObjectStruct{TEXT("schematic"), Schematic->GetPathName()});
-            SchematicManager->mPurchasedSchematics.Remove(Schematic);
+        if (!IsSchematicRegistered(Schematic)) {
+            if (!Schematic->GetPathName().StartsWith("/Game/FactoryGame")) {
+                MissingObjects.Add(FMissingObjectStruct{ TEXT("schematic"), Schematic->GetPathName() });
+                SchematicManager->mPurchasedSchematics.Remove(Schematic);
+            }
+            else {
+                UnregisteredObjects.Add(FMissingObjectStruct{ TEXT("schematic"), Schematic->GetPathName() });
+            }
         }
     }
     //Do same thing for incomplete schematic progress
     SchematicManager->mPaidOffSchematic.RemoveAll([&](const FSchematicCost& SchematicCost) {
-        return !IsSchematicRegistered(SchematicCost.Schematic);
+        return !IsSchematicRegistered(SchematicCost.Schematic) && !SchematicCost.Schematic->GetPathName().StartsWith("/Game/FactoryGame");
     });
 }
 
 void AModContentRegistry::FindMissingResearchTrees(AFGResearchManager* ResearchManager,
-                                                   TArray<FMissingObjectStruct>& MissingObjects) const {
+                                                   TArray<FMissingObjectStruct>& MissingObjects,
+                                                   TArray<FMissingObjectStruct>& UnregisteredObjects) const {
     //Clear unlocked research trees
     TArray<TSubclassOf<UFGResearchTree>> UnlockedResearchTrees = ResearchManager->mUnlockedResearchTrees;
     for (const TSubclassOf<UFGResearchTree>& ResearchTree : UnlockedResearchTrees) {
         if (!IsResearchTreeRegistered(ResearchTree)) {
-            ResearchManager->mUnlockedResearchTrees.Remove(ResearchTree);
-            MissingObjects.Add(FMissingObjectStruct{TEXT("research_tree"), ResearchTree->GetPathName()});
+            if (!ResearchTree->GetPathName().StartsWith("/Game/FactoryGame")) {
+                ResearchManager->mUnlockedResearchTrees.Remove(ResearchTree);
+                MissingObjects.Add(FMissingObjectStruct{ TEXT("research_tree"), ResearchTree->GetPathName() });
+            }
+            else {
+                UnregisteredObjects.Add(FMissingObjectStruct{ TEXT("research_tree"), ResearchTree->GetPathName() });
+            }
         }
     }
-    
+
     //Clear completed, but unclaimed researches
     ResearchManager->mCompletedResearch.RemoveAll([&](const FResearchData& ResearchData) {
-        return !IsResearchTreeRegistered(ResearchData.InitiatingResearchTree) ||
-            !IsSchematicRegistered(ResearchData.Schematic);
+        if (ResearchData.Schematic->GetPathName().StartsWith("/Game/FactoryGame") ||
+            ResearchData.InitiatingResearchTree->GetPathName().StartsWith("/Game/FactoryGame")) {
+            return false;
+        }
+        else {
+            return (!IsResearchTreeRegistered(ResearchData.InitiatingResearchTree) ||
+                !IsSchematicRegistered(ResearchData.Schematic));
+        }
     });
-    
+
     //Clear ongoing research data
     ResearchManager->mOngoingResearch.RemoveAll([&](const FResearchTime& ResearchTime){
-        return !IsResearchTreeRegistered(ResearchTime.ResearchData.InitiatingResearchTree) ||
-          !IsSchematicRegistered(ResearchTime.ResearchData.Schematic);
+        if (ResearchTime.ResearchData.Schematic->GetPathName().StartsWith("/Game/FactoryGame") ||
+            ResearchTime.ResearchData.InitiatingResearchTree->GetPathName().StartsWith("/Game/FactoryGame")) {
+            return false;
+        }
+        else {
+            return (!IsResearchTreeRegistered(ResearchTime.ResearchData.InitiatingResearchTree) ||
+                !IsSchematicRegistered(ResearchTime.ResearchData.Schematic));
+        }
     });
 }
 
 void AModContentRegistry::FindMissingRecipes(AFGRecipeManager* RecipeManager,
-                                             TArray<FMissingObjectStruct>& MissingObjects) const {
+                                                   TArray<FMissingObjectStruct>& MissingObjects,
+                                                   TArray<FMissingObjectStruct>& UnregisteredObjects) const {
     //Clear unlocked recipes
     TArray<TSubclassOf<UFGRecipe>> UnlockedRecipes = RecipeManager->mAvailableRecipes;
     for (const TSubclassOf<UFGRecipe>& Recipe : UnlockedRecipes) {
-        if (!IsRecipeRegistered(Recipe) && !Recipe->GetPathName().StartsWith("/Game/FactoryGame")) {
-            RecipeManager->mAvailableRecipes.Remove(Recipe);
-            MissingObjects.Add(FMissingObjectStruct{TEXT("recipe"), Recipe->GetPathName()});
+        if (!IsRecipeRegistered(Recipe)) {
+            if (!Recipe->GetPathName().StartsWith("/Game/FactoryGame")) {
+                RecipeManager->mAvailableRecipes.Remove(Recipe);
+                MissingObjects.Add(FMissingObjectStruct{ TEXT("recipe"), Recipe->GetPathName() });
+            }
+            else {
+                UnregisteredObjects.Add(FMissingObjectStruct{ TEXT("recipe"), Recipe->GetPathName() });
+            }
         }
     }
 }
@@ -364,6 +398,16 @@ void AModContentRegistry::WarnAboutMissingObjects(const TArray<FMissingObjectStr
     UE_LOG(LogContentRegistry, Error, TEXT("---------------------------------------------"));
 }
 
+void AModContentRegistry::WarnAboutUnregisteredObjects(const TArray<FMissingObjectStruct>& UnregisteredObjects) {
+    UE_LOG(LogContentRegistry, Error, TEXT("---------------------------------------------"));
+    UE_LOG(LogContentRegistry, Error, TEXT("Found unregistered FactoryGame objects referenced in savegame:"));
+    for (const FMissingObjectStruct& ObjectStruct : UnregisteredObjects) {
+        UE_LOG(LogContentRegistry, Error, TEXT("%s: %s"), *ObjectStruct.ObjectType, *ObjectStruct.ObjectPath);
+    }
+    UE_LOG(LogContentRegistry, Error, TEXT("They will NOT be cleared out"));
+    UE_LOG(LogContentRegistry, Error, TEXT("---------------------------------------------"));
+}
+
 void AModContentRegistry::AddReferencedObjects(UObject* InThis, FReferenceCollector& Collector) {
     AModContentRegistry* ModContentRegistry = Cast<AModContentRegistry>(InThis);
     //Register all non-UPROPERTY referenced objects from registry states (registry states cannot be UPROPERTY() because they are templates!)
@@ -375,7 +419,7 @@ void AModContentRegistry::AddReferencedObjects(UObject* InThis, FReferenceCollec
 
 void AModContentRegistry::RegisterSchematic(const FName ModReference, const TSubclassOf<UFGSchematic> Schematic) {
 	CHECK_PROVIDED_OBJECT_VALID(Schematic, TEXT("Attempt to register NULL Schematic. Mod Reference: %s"), *ModReference.ToString());
-	
+
     if (!SchematicRegistryState.ContainsObject(Schematic)) {
         EnsureRegistryUnfrozen();
 
@@ -391,7 +435,7 @@ void AModContentRegistry::RegisterSchematic(const FName ModReference, const TSub
     	for (const TSubclassOf<UFGRecipe>& Recipe : OutReferencedRecipes) {
     		CHECK_PROVIDED_OBJECT_VALID(Recipe, TEXT("Schematic '%s' registered by %s references invalid NULL Recipe in it's Unlocks Array"),
     			*Schematic->GetPathName(), *ModReference.ToString());
-        	
+
             RegisterRecipe(ModReference, Recipe);
             const TSharedPtr<FRecipeRegistrationInfo> RecipeRegistrationInfo = RecipeRegistryState.FindObject(Recipe);
             RecipeRegistrationInfo->ReferencedBy.Add(Schematic);
@@ -412,20 +456,20 @@ void AModContentRegistry::RegisterResearchTree(const FName ModReference, const T
         const FName OwnerModReference = FindContentOwnerFast(ResearchTree);
         const TSharedPtr<FResearchTreeRegistrationInfo> RegistrationInfo = ResearchTreeRegistryState.RegisterObject(
             MakeRegistrationInfo<FResearchTreeRegistrationInfo>(ResearchTree, OwnerModReference, ModReference));
-        
+
         //Register referenced schematics automatically and associate research tree with them
         TArray<TSubclassOf<UFGSchematic>> OutReferencedSchematics;
         ExtractSchematicsFromResearchTree(ResearchTree, OutReferencedSchematics);
-    	
+
         for (const TSubclassOf<UFGSchematic>& Schematic : OutReferencedSchematics) {
         	CHECK_PROVIDED_OBJECT_VALID(Schematic, TEXT("ResearchTree '%s' registered by %s references invalid NULL Schematic in one of it's Nodes"),
         		*ResearchTree->GetPathName(), *ModReference.ToString());
-        	
+
             RegisterSchematic(ModReference, Schematic);
             const TSharedPtr<FSchematicRegistrationInfo> SchematicRegistrationInfo = SchematicRegistryState.FindObject(Schematic);
             SchematicRegistrationInfo->ReferencedBy.Add(ResearchTree);
         }
-        
+
         //Process registration callback
         OnResearchTreeRegistered.Broadcast(ResearchTree, *RegistrationInfo);
     }
@@ -436,7 +480,6 @@ void AModContentRegistry::RegisterRecipe(const FName ModReference, const TSubcla
 
     if (!RecipeRegistryState.ContainsObject(Recipe)) {
         EnsureRegistryUnfrozen();
-        
         //Create registration entry and register
         const FName OwnerModReference = FindContentOwnerFast(Recipe);
         const TSharedPtr<FRecipeRegistrationInfo> RegistrationInfo = RecipeRegistryState.RegisterObject(
@@ -455,11 +498,11 @@ void AModContentRegistry::RegisterRecipe(const FName ModReference, const TSubcla
 
 void AModContentRegistry::RegisterResourceSinkItemPointTable(FName ModReference, UDataTable* PointTable) {
 	CHECK_PROVIDED_OBJECT_VALID(PointTable, TEXT("Attempt to register NULL ResourceSinkPointTable. Mod Reference: %s"), *ModReference.ToString());
-	
+
 	checkf(PointTable->RowStruct != nullptr && PointTable->RowStruct->IsChildOf(FResourceSinkPointsData::StaticStruct()),
             TEXT("Invalid AWESOME Sink item points table in mod %s (%s): Row Type should be Resource Sink Points Data"),
             *ModReference.ToString(), *PointTable->GetPathName());
-	
+
 	this->PendingItemSinkPointsRegistrations.Add(PointTable, ModReference);
 	FlushPendingResourceSinkRegistrations();
 }
@@ -468,7 +511,7 @@ TArray<FItemRegistrationInfo> AModContentRegistry::GetLoadedItemDescriptors() {
     //Since we don't have consistent registry, we have to iterate all loaded classes and generate information from them
     //We also keep all referenced classes loaded, so they will be included there too
     TArray<FItemRegistrationInfo> OutRegistrationInfo;
-    
+
     UClass* ItemDescriptorClass = UFGItemDescriptor::StaticClass();
     ForEachObjectOfClass(UClass::StaticClass(), [&](UObject* LoadedClassObject) {
         UClass* Class = Cast<UClass>(LoadedClassObject);
@@ -484,7 +527,7 @@ TArray<FItemRegistrationInfo> AModContentRegistry::GetObtainableItemDescriptors(
     //All obtainable item descriptors are guaranteed to be present in ItemDescriptorRegistrationList,
     //So we can just iterate it and filter item descriptors without associated recipes out
     TArray<FItemRegistrationInfo> OutRegistrationInfo;
-    
+
     for (const TSharedPtr<FItemRegistrationInfo>& RegistrationInfo : ItemRegistryState.GetAllObjects()) {
         if (RegistrationInfo->ReferencedBy.Num() > 0) {
             OutRegistrationInfo.Add(*RegistrationInfo);
@@ -498,13 +541,13 @@ FItemRegistrationInfo AModContentRegistry::GetItemDescriptorInfo(const TSubclass
 	if (!IsValid(ItemDescriptor)) {
 		return FItemRegistrationInfo{};
 	}
-	
+
     //Use cached registration information if it's available
     const TSharedPtr<FItemRegistrationInfo> CachedRegistrationInfo = ItemRegistryState.FindObject(ItemDescriptor);
     if (CachedRegistrationInfo.IsValid()) {
         return *CachedRegistrationInfo;
     }
-	
+
     //Item descriptor was not referenced in any registered recipe, fallback to registrar name = owner name logic
     const FName OwnerModReference = FindContentOwnerFast(ItemDescriptor);
     return *RegisterItemDescriptor(OwnerModReference, OwnerModReference, ItemDescriptor);
@@ -517,7 +560,7 @@ AModContentRegistry::AModContentRegistry() {
     bSubscribedToSchematicManager = false;
     PrimaryActorTick.bCanEverTick = true;
 	ActiveScriptFramePtr = NULL;
-	
+
 	//Mod Content Registry is always Local and Spawned on both Client and Server separately
 	this->ReplicationPolicy = ESubsystemReplicationPolicy::SpawnLocal;
 }
@@ -526,13 +569,13 @@ AModContentRegistry* AModContentRegistry::Get(UObject* WorldContext) {
 	UWorld* WorldObject = GEngine->GetWorldFromContextObjectChecked(WorldContext);
     USubsystemActorManager* SubsystemActorManager = WorldObject->GetSubsystem<USubsystemActorManager>();
 	check(SubsystemActorManager);
-	
+
 	return SubsystemActorManager->GetSubsystemActor<AModContentRegistry>();
 }
 
 void AModContentRegistry::BeginPlay() {
 	Super::BeginPlay();
-	
+
     //We should be frozen at this point already on host clients (freezing there happens before BeginPlay is dispatched to world actors)
 	//For remote clients we are not frozen yet most likely, but checking save data for remote clients is pointless anyway
     if (HasAuthority()) {
@@ -555,10 +598,10 @@ void AModContentRegistry::Tick(float DeltaSeconds) {
     //Make sure vanilla states are up to date with registry
     AFGSchematicManager* SchematicManager = AFGSchematicManager::Get(this);
     AFGResearchManager* ResearchManager = AFGResearchManager::Get(this);
-    
+
     if (SchematicManager != NULL) {
         const int64 SchematicRegistryCounter = SchematicRegistryState.GetRegistrationCounter();
-        
+
         if (SchematicRegistryCounter > SchematicManagerInternalState) {
             FlushStateToSchematicManager(SchematicManager);
             SchematicManagerInternalState = SchematicRegistryCounter;
@@ -569,10 +612,10 @@ void AModContentRegistry::Tick(float DeltaSeconds) {
             bSubscribedToSchematicManager = true;
         }
     }
-    
+
     if (ResearchManager != NULL) {
         const int64 ResearchTreeRegistryCounter = ResearchTreeRegistryState.GetRegistrationCounter();
-        
+
         if (ResearchTreeRegistryCounter > ResearchManagerInternalState) {
             FlushStateToResearchManager(ResearchManager);
             ResearchManagerInternalState = ResearchTreeRegistryCounter;
@@ -590,7 +633,7 @@ void AModContentRegistry::FlushPendingResourceSinkRegistrations() {
 	if (ResourceSinkSubsystem != NULL) {
 		for (const TPair<UDataTable*, FName>& Pair : PendingItemSinkPointsRegistrations) {
 			UE_LOG(LogContentRegistry, Log, TEXT("Registering Resource Sink Points Table '%s' from Mod %s"), *Pair.Key->GetPathName(), *Pair.Value.ToString());;
-			
+
 			TArray<FResourceSinkPointsData*> OutModPointsData;
 			Pair.Key->GetAllRows(TEXT("ResourceSinkPointsData"), OutModPointsData);
 			for (FResourceSinkPointsData* ModItemRow : OutModPointsData) {
@@ -598,7 +641,7 @@ void AModContentRegistry::FlushPendingResourceSinkRegistrations() {
 				ResourceSinkSubsystem->mResourceSinkPoints.Add(ModItemRow->ItemClass, Points);
 			}
 		}
-		
+
 		PendingItemSinkPointsRegistrations.Empty();
 	}
 }

--- a/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
+++ b/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
@@ -307,7 +307,7 @@ void AModContentRegistry::FindMissingSchematics(AFGSchematicManager* SchematicMa
     //Clear references to unlocked schematics if they are not registered
     TArray<TSubclassOf<UFGSchematic>> PurchasedSchematics = SchematicManager->mPurchasedSchematics;
     for (const TSubclassOf<UFGSchematic> Schematic : PurchasedSchematics) {
-        if (!IsSchematicRegistered(Schematic)) {
+        if (!IsSchematicRegistered(Schematic) && !Schematic->GetPathName().StartsWith("/Game/FactoryGame")) {
             MissingObjects.Add(FMissingObjectStruct{TEXT("schematic"), Schematic->GetPathName()});
             SchematicManager->mPurchasedSchematics.Remove(Schematic);
         }
@@ -347,7 +347,7 @@ void AModContentRegistry::FindMissingRecipes(AFGRecipeManager* RecipeManager,
     //Clear unlocked recipes
     TArray<TSubclassOf<UFGRecipe>> UnlockedRecipes = RecipeManager->mAvailableRecipes;
     for (const TSubclassOf<UFGRecipe>& Recipe : UnlockedRecipes) {
-        if (!IsRecipeRegistered(Recipe)) {
+        if (!IsRecipeRegistered(Recipe) && !Recipe->GetPathName().StartsWith("/Game/FactoryGame")) {
             RecipeManager->mAvailableRecipes.Remove(Recipe);
             MissingObjects.Add(FMissingObjectStruct{TEXT("recipe"), Recipe->GetPathName()});
         }

--- a/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
+++ b/Plugins/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
@@ -324,7 +324,7 @@ void AModContentRegistry::FindMissingSchematics(AFGSchematicManager* SchematicMa
     }
     //Do same thing for incomplete schematic progress
     SchematicManager->mPaidOffSchematic.RemoveAll([&](const FSchematicCost& SchematicCost) {
-        return !IsSchematicRegistered(SchematicCost.Schematic) && !SchematicCost.Schematic->GetPathName().StartsWith("/Game/FactoryGame");
+        return !IsSchematicRegistered(SchematicCost.Schematic) && !IsSchematicVanilla(SchematicCost.Schematic);
     });
 }
 

--- a/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -74,10 +74,10 @@ template<typename T>
 struct SML_API TInternalRegistryState {
 private:
     using KeyType = decltype(((T*)0)->RegisteredObject);
-    
+
     TArray<TSharedPtr<T>> RegistrationList;
     TMap<KeyType, TSharedPtr<T>> RegistrationMap;
-    
+
     //Used for fast AddReferencedObjects implementation
     //It cannot be UPROPERTY() because UHT won't understand UPROPERTY() declaration inside template struct
     TArray<UObject*> ReferencedObjects;
@@ -88,7 +88,7 @@ public:
     FORCEINLINE bool ContainsObject(const KeyType& KeyType) const {
         return RegistrationMap.Contains(KeyType);
     }
-    
+
     FORCEINLINE TSharedPtr<T> RegisterObject(const T& ObjectInfo) {
         check(!ContainsObject(ObjectInfo.RegisteredObject));
         TSharedPtr<T> RegistrationEntry = MakeShareable(new T{ObjectInfo});
@@ -132,7 +132,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnRecipeRegistered, TSubclassOf<UF
  * All modded content of supported types should be registered there
  * to be correctly saved, loaded and identified by the game
  * and other information mods
- * 
+ *
  * If you don't need any dynamic behaviors, use properties in InitGameWorld instead
  * of calling methods on this object directly
  *
@@ -144,7 +144,7 @@ class SML_API AModContentRegistry : public AModSubsystem {
     GENERATED_BODY()
 public:
     AModContentRegistry();
-    
+
     /** Retrieves global mod content registry instance */
 	UFUNCTION(BlueprintPure, DisplayName = "GetModContentRegistry", meta = (DefaultToSelf = "WorldContext"))
     static AModContentRegistry* Get(UObject* WorldContext);
@@ -153,7 +153,7 @@ public:
      * Registers schematic to be usable by the game
      *    All recipes referenced by schematic are registered automatically
      *    All items referenced by registered recipes are associated with passed mod reference too
-     * 
+     *
      * @param ModReference identifier of the mod who is performing this registration
      * @param Schematic class of schematic to be registered
      */
@@ -182,7 +182,7 @@ public:
      */
     UFUNCTION(BlueprintCallable, CustomThunk)
     void RegisterRecipe(const FName ModReference, TSubclassOf<UFGRecipe> Recipe);
-    
+
     /** Register resource sink item points for each item row in the passed table object */
     UFUNCTION(BlueprintCallable, CustomThunk)
     void RegisterResourceSinkItemPointTable(const FName ModReference, UDataTable* PointTable);
@@ -208,7 +208,7 @@ public:
         }
         return RegistrationInfos;
     }
-    
+
     /** Retrieves registration entry for recipe */
     UFUNCTION(BlueprintPure)
     FORCEINLINE FRecipeRegistrationInfo GetRecipeInfo(TSubclassOf<UFGRecipe> Recipe) const {
@@ -225,7 +225,7 @@ public:
         }
         return RegistrationInfos;
     }
-    
+
     /** Retrieves registration entry for research tree */
     UFUNCTION(BlueprintPure)
     FORCEINLINE FResearchTreeRegistrationInfo GetResearchTreeRegistrationInfo(TSubclassOf<UFGResearchTree> ResearchTree) const {
@@ -242,7 +242,7 @@ public:
         }
         return RegistrationInfos;
     }
-    
+
     /** Retrieves registration entry for schematic */
     UFUNCTION(BlueprintPure)
     FORCEINLINE FSchematicRegistrationInfo GetSchematicRegistrationInfo(TSubclassOf<UFGSchematic> Schematic) const {
@@ -253,9 +253,9 @@ public:
     /** Returns true when given recipe is registered */
     UFUNCTION(BlueprintPure)
     FORCEINLINE bool IsRecipeRegistered(TSubclassOf<UFGRecipe> Recipe) const {
-        return Recipe != NULL && RecipeRegistryState.ContainsObject(Recipe);    
+        return Recipe != NULL && RecipeRegistryState.ContainsObject(Recipe);
     }
-    
+
     /** Returns true when given schematic is registered */
     UFUNCTION(BlueprintPure)
     FORCEINLINE bool IsSchematicRegistered(TSubclassOf<UFGSchematic> Schematic) const {
@@ -273,9 +273,9 @@ public:
 
     //Add objects from registry states to reference collector
     static void AddReferencedObjects(UObject* InThis, FReferenceCollector& Collector);
-	
+
 	//Callbacks to be fired when new entries are registered
-	
+
 	/** Called when recipe is registered into content registry */
 	UPROPERTY(BlueprintAssignable)
 	FOnRecipeRegistered OnRecipeRegistered;
@@ -348,7 +348,7 @@ private:
 
 	/** Flushed pending resource sink registrations into the resource sink subsystem, if it is available */
 	void FlushPendingResourceSinkRegistrations();
-   
+
     /** Freezes registry in place and clears out all unreferenced objects */
     void FreezeRegistryState();
     /** Ensures that registry is not frozen and we can perform registration */
@@ -361,19 +361,20 @@ private:
     /** Called when schematic is purchased in schematic manager */
     UFUNCTION()
     void OnSchematicPurchased(TSubclassOf<UFGSchematic> Schematic);
-    
+
     /** Associate items referenced in recipe with given mod reference if they are not associated already */
     void MarkItemDescriptorsFromRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
-    
+
     /** Associate the customization recipe referenced in recipe with given mod reference if it is not associated already */
     void MarkCustomizationRecipeFromRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
 
     TSharedPtr<FItemRegistrationInfo> RegisterItemDescriptor(const FName OwnerModReference, const FName RegistrarModReference, const TSubclassOf<UFGItemDescriptor>& ItemDescriptor);
 
-    void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects) const;
-    void FindMissingResearchTrees(class AFGResearchManager* ResearchManager, TArray<FMissingObjectStruct>& MissingObjects) const;
-    void FindMissingRecipes(class AFGRecipeManager* RecipeManager, TArray<FMissingObjectStruct>& MissingObjects) const;
+    void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
+    void FindMissingResearchTrees(class AFGResearchManager* ResearchManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
+    void FindMissingRecipes(class AFGRecipeManager* RecipeManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
     static void WarnAboutMissingObjects(const TArray<FMissingObjectStruct>& MissingObjects);
+    static void WarnAboutUnregisteredObjects(const TArray<FMissingObjectStruct>& UnregisteredObjects);
 
     template<typename T>
     FORCEINLINE static T MakeRegistrationInfo(UClass* Class, const FName OwnedByModReference, const FName RegisteredByModReference) {

--- a/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -386,8 +386,6 @@ private:
     /** Associate the customization recipe referenced in recipe with given mod reference if it is not associated already */
     void MarkCustomizationRecipeFromRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
 
-    void MarkSkinFromSchematic(const TSubclassOf<UFGSchematic>& Schematic, const FName ModReference);
-
     TSharedPtr<FItemRegistrationInfo> RegisterItemDescriptor(const FName OwnerModReference, const FName RegistrarModReference, const TSubclassOf<UFGItemDescriptor>& ItemDescriptor);
 
     void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredVanillaObjects) const;

--- a/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -396,9 +396,9 @@ private:
 
     TSharedPtr<FItemRegistrationInfo> RegisterItemDescriptor(const FName OwnerModReference, const FName RegistrarModReference, const TSubclassOf<UFGItemDescriptor>& ItemDescriptor);
 
-    void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
-    void FindMissingResearchTrees(class AFGResearchManager* ResearchManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
-    void FindMissingRecipes(class AFGRecipeManager* RecipeManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
+    void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredVanillaObjects) const;
+    void FindMissingResearchTrees(class AFGResearchManager* ResearchManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredVanillaObjects) const;
+    void FindMissingRecipes(class AFGRecipeManager* RecipeManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredVanillaObjects) const;
     static void WarnAboutMissingObjects(const TArray<FMissingObjectStruct>& MissingObjects);
     static void WarnAboutUnregisteredVanillaObjects(const TArray<FMissingObjectStruct>& UnregisteredVanillaObjects);
 

--- a/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -268,6 +268,24 @@ public:
         return ResearchTree != NULL && ResearchTreeRegistryState.ContainsObject(ResearchTree);
     }
 
+    /** Returns true when given recipe is vanilla */
+    UFUNCTION(BlueprintPure)
+        FORCEINLINE bool IsRecipeVanilla(TSubclassOf<UFGRecipe> Recipe) const {
+        return Recipe != NULL && Recipe->GetPathName().StartsWith("/Game/FactoryGame");
+    }
+
+    /** Returns true when given schematic is vanilla */
+    UFUNCTION(BlueprintPure)
+        FORCEINLINE bool IsSchematicVanilla(TSubclassOf<UFGSchematic> Schematic) const {
+        return Schematic != NULL && Schematic->GetPathName().StartsWith("/Game/FactoryGame");
+    }
+
+    /** Returns true when given research tree is vanilla */
+    UFUNCTION(BlueprintPure)
+        FORCEINLINE bool IsResearchTreeVanilla(TSubclassOf<UFGResearchTree> ResearchTree) const {
+        return ResearchTree != NULL && ResearchTree->GetPathName().StartsWith("/Game/FactoryGame");
+    }
+
     virtual void BeginPlay() override;
     virtual void Tick(float DeltaSeconds) override;
 
@@ -368,13 +386,21 @@ private:
     /** Associate the customization recipe referenced in recipe with given mod reference if it is not associated already */
     void MarkCustomizationRecipeFromRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
 
+    void MarkCustomizationRecipeFromDescriptor(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
+
+    void MarkSkinFromSchematic(const TSubclassOf<UFGSchematic>& Schematic, const FName ModReference);
+
+    void MarkFactoryGameSchematic(const TSubclassOf<UFGSchematic>& Schematic, const FName ModReference);
+    void MarkFactoryGameRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
+
+
     TSharedPtr<FItemRegistrationInfo> RegisterItemDescriptor(const FName OwnerModReference, const FName RegistrarModReference, const TSubclassOf<UFGItemDescriptor>& ItemDescriptor);
 
     void FindMissingSchematics(class AFGSchematicManager* SchematicManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
     void FindMissingResearchTrees(class AFGResearchManager* ResearchManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
     void FindMissingRecipes(class AFGRecipeManager* RecipeManager, TArray<FMissingObjectStruct>& MissingObjects, TArray<FMissingObjectStruct>& UnregisteredObjects) const;
     static void WarnAboutMissingObjects(const TArray<FMissingObjectStruct>& MissingObjects);
-    static void WarnAboutUnregisteredObjects(const TArray<FMissingObjectStruct>& UnregisteredObjects);
+    static void WarnAboutUnregisteredVanillaObjects(const TArray<FMissingObjectStruct>& UnregisteredVanillaObjects);
 
     template<typename T>
     FORCEINLINE static T MakeRegistrationInfo(UClass* Class, const FName OwnedByModReference, const FName RegisteredByModReference) {

--- a/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Plugins/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -386,13 +386,7 @@ private:
     /** Associate the customization recipe referenced in recipe with given mod reference if it is not associated already */
     void MarkCustomizationRecipeFromRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
 
-    void MarkCustomizationRecipeFromDescriptor(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
-
     void MarkSkinFromSchematic(const TSubclassOf<UFGSchematic>& Schematic, const FName ModReference);
-
-    void MarkFactoryGameSchematic(const TSubclassOf<UFGSchematic>& Schematic, const FName ModReference);
-    void MarkFactoryGameRecipe(const TSubclassOf<UFGRecipe>& Recipe, const FName ModReference);
-
 
     TSharedPtr<FItemRegistrationInfo> RegisterItemDescriptor(const FName OwnerModReference, const FName RegistrarModReference, const TSubclassOf<UFGItemDescriptor>& ItemDescriptor);
 


### PR DESCRIPTION
Added checks to prevent removal of any object that originated in the FactoryGame project, regardless of whether they are registered. 

Added new warning message to display any occurrences of this.