### PR TITLE
Remove Enum MAX from Configs

### DIFF
--- a/Plugins/SML/Source/SML/Private/Configuration/Properties/WidgetExtension/CP_Integer.cpp
+++ b/Plugins/SML/Source/SML/Private/Configuration/Properties/WidgetExtension/CP_Integer.cpp
@@ -10,10 +10,11 @@ UCP_Integer::UCP_Integer() {
 TArray<FName> UCP_Integer::GetEnumNames() const {
 	if (EnumClass) {
 		TArray<FName> Out;
-		for (int32 i = 0; i < EnumClass->NumEnums(); i++) {
+		int32 EnumCount = EnumClass->ContainsExistingMax() ? EnumClass->NumEnums() - 1 : EnumClass->NumEnums();
+		for (int32 i = 0; i < EnumCount; i++) {
 			Out.Add(*EnumClass->GetDisplayNameTextByIndex(i).ToString());
 		}
 		return Out;
-	}	
+	}
 	return TArray<FName>();
 }


### PR DESCRIPTION
Prevents the [EnumName]_MAX value from showing in mod configs that use the int-based enum drop-down. 
Before: https://i.imgur.com/boskkUV.jpeg
After: https://i.imgur.com/vWYWYgr.jpeg

If there is a better method of doing this, I'm all for it. This was the only way I could think of that didn't involve string matching.