### PR TITLE
Add SML_API to LogNativeHookManager

### DIFF
--- a/Plugins/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Plugins/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -3,7 +3,7 @@
 #include <functional>
 #include <type_traits>
 
-DECLARE_LOG_CATEGORY_EXTERN(LogNativeHookManager, Log, Log);
+SML_API DECLARE_LOG_CATEGORY_EXTERN(LogNativeHookManager, Log, Log);
 
 //NOTE: This struct does not actually fully represent member function pointer even on MSVC,
 //because it does not contain additional information for handling unknown inheritance


### PR DESCRIPTION
Add SML_API to LogNativeHookManager needed for MrHid6 to build FicsitFarming for linux.

EDIT: PR is being gutted to be just the SML_API change for MrHid6, Updating this soon

Originally, This contained an attempted (incorrect) fix for dependencies on linux and a change needed for MrHid6. It is now just the change for MrHid6