### PR TITLE
Add HookOffsetStart bool to BindOnBPFunction

### DIFF
--- a/Plugins/SML/Source/SML/Private/Util/RuntimeBlueprintFunctionLibrary.cpp
+++ b/Plugins/SML/Source/SML/Private/Util/RuntimeBlueprintFunctionLibrary.cpp
@@ -342,7 +342,7 @@ void URuntimeBlueprintFunctionLibrary::SetComboBoxFont(UComboBoxString* Box, FSl
 	Box->Font = Font;
 }
 
-void URuntimeBlueprintFunctionLibrary::BindOnBPFunction(const TSubclassOf<UObject> Class, FObjFunctionBind Binding, const FString FunctionName)
+void URuntimeBlueprintFunctionLibrary::BindOnBPFunction(const TSubclassOf<UObject> Class, FObjFunctionBind Binding, const FString FunctionName, bool HookOffsetStart)
 {
 		if(!Class)
 			return;
@@ -362,8 +362,9 @@ void URuntimeBlueprintFunctionLibrary::BindOnBPFunction(const TSubclassOf<UObjec
 
 			return;
 		}
+		EPredefinedHookOffset Offset = HookOffsetStart ? EPredefinedHookOffset::Start : EPredefinedHookOffset::Return;
 		UBlueprintHookManager* HookManager = GEngine->GetEngineSubsystem<UBlueprintHookManager>();
 		HookManager->HookBlueprintFunction(Function, [Binding](FBlueprintHookHelper& HookHelper) {
             Binding.ExecuteIfBound(HookHelper.GetContext());
-        }, EPredefinedHookOffset::Return);
+        }, Offset);
 }

--- a/Plugins/SML/Source/SML/Public/Util/RuntimeBlueprintFunctionLibrary.h
+++ b/Plugins/SML/Source/SML/Public/Util/RuntimeBlueprintFunctionLibrary.h
@@ -143,7 +143,7 @@ public:
 
 		/** Allows Binding on BP Function. Function must be implemented in Blueprint */
 		UFUNCTION(BlueprintCallable)
-		static void BindOnBPFunction(const TSubclassOf<UObject> Class, FObjFunctionBind Binding, const FString FunctionName);
+		static void BindOnBPFunction(const TSubclassOf<UObject> Class, FObjFunctionBind Binding, const FString FunctionName, bool HookOffsetStart);
 	
 
 };


### PR DESCRIPTION
Add bool to optionally set hooks from BP to have the offset set to Start instead of always being Return. Backwards compatible with existing usage of BindOnBPFunction.