### PR TITLE
Remove build-erroring unused Prop field

### DIFF
--- a/Plugins/SML/Source/SML/Public/Patching/BlueprintHookHelper.h
+++ b/Plugins/SML/Source/SML/Public/Patching/BlueprintHookHelper.h
@@ -44,7 +44,6 @@ public:
 	typename T::TCppType* GetLocalVarPtr(const TCHAR* ParameterName, int32 ArrayIndex = 0) const {
 		T* Property = Cast<T>(FramePointer.Node->FindPropertyByName(ParameterName));
 		check(Property);
-		UProperty* Prop;
 		checkf(!Property->HasAnyPropertyFlags(CPF_OutParm), TEXT("Attempt to use GetLocalVarPtr on [out] variable"));
 		return Property->GetPropertyValuePtr_InContainer(FramePointer.Locals, ArrayIndex);
 	}


### PR DESCRIPTION
See this conversation in `#cpp-help` on the Discord: https://discord.com/channels/555424930502541343/862002356626128907/1024907614817112095