### PR TITLE
Specify C++ module dependencies to silence VS warning

### DIFF
--- a/Plugins/SML/SML.uplugin
+++ b/Plugins/SML/SML.uplugin
@@ -21,5 +21,39 @@
 			"Type": "Runtime",
 			"LoadingPhase": "PostDefault"
 		}
+	],
+	"Plugins": [
+		{
+			"Name": "OnlineSubsystem",
+			"Enabled": true
+		},
+		{
+			"Name": "OnlineSubsystemNull",
+			"Enabled": true
+		},
+		{
+			"Name": "OnlineSubsystemUtils",
+			"Enabled": true
+		},
+		{
+			"Name": "SignificanceManager",
+			"Enabled": true
+		},
+		{
+			"Name": "ApexDestruction",
+			"Enabled": true
+		},
+		{
+			"Name": "Wwise",
+			"Enabled": true
+		},
+		{
+			"Name": "PhysXVehicles",
+			"Enabled": true
+		},
+		{
+			"Name": "ReplicationGraph",
+			"Enabled": true
+		}
 	]
 }

--- a/Plugins/SMLEditor/SMLEditor.uplugin
+++ b/Plugins/SMLEditor/SMLEditor.uplugin
@@ -20,5 +20,43 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default"
 		}
+	],
+	"Plugins": [
+		{
+			"Name": "SML",
+			"Enabled": true
+		},
+		{
+			"Name": "OnlineSubsystem",
+			"Enabled": true
+		},
+		{
+			"Name": "OnlineSubsystemNull",
+			"Enabled": true
+		},
+		{
+			"Name": "OnlineSubsystemUtils",
+			"Enabled": true
+		},
+		{
+			"Name": "SignificanceManager",
+			"Enabled": true
+		},
+		{
+			"Name": "ApexDestruction",
+			"Enabled": true
+		},
+		{
+			"Name": "Wwise",
+			"Enabled": true
+		},
+		{
+			"Name": "PhysXVehicles",
+			"Enabled": true
+		},
+		{
+			"Name": "ReplicationGraph",
+			"Enabled": true
+		}
 	]
 }


### PR DESCRIPTION
ex. `UnrealBuildTool: Warning: Plugin ‘SML’ does not list plugin ‘OnlineSubsystem’ as a dependency, but module ‘SML’ depends on ‘OnlineSubsystem’`

https://forums.unrealengine.com/t/unrealbuildtool-dependancy-warning/404128 