### PR TITLE
Remove deprecated ContactShadows option

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -6,7 +6,6 @@ net.UseAdaptiveNetUpdateFrequency=0
 net.DoPacketOrderCorrection=1
 net.IsPushModelEnabled=1
 r.SkyLight.RealTimeReflectionCapture.TimeSlice=1
-r.ContactShadows.NonShadowCastingIntensity=0.75
 r.HZBOcclussion=0
 wp.Runtime.EnableServerStreaming=1
 wp.Runtime.EnableServerStreamingOut=true


### PR DESCRIPTION
The `r.ContactShadows.NonShadowCastingIntensity` setting is deprecated, and the editor shows a warning about its value being ignored. Drop the corresponding line from the `DefaultEngine.ini` config file so that the warning no longer appears in the editor.

TEST=Launch UE editor, observe no red warning text appears.