### PR TITLE
ModContentRegistry: Filter item descriptor by resource form

### DIFF
--- a/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -5,6 +5,7 @@
 #include "FGRecipe.h"
 #include "FGResourceSinkSubsystem.h"
 #include "Engine/DataTable.h"
+#include "Misc/EnumClassFlags.h"
 #include "ModContentRegistry.generated.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogContentRegistry, Log, All);
@@ -139,6 +140,8 @@ enum class EGetObtainableItemDescriptorsFlags : uint8
 	IncludeSpecial = 0x20 UMETA( DisplayName = "Include Special (WildCard, AnyUndefined, Overflow, None)" ),
 	Default = None,
 };
+
+ENUM_CLASS_FLAGS(EGetObtainableItemDescriptorsFlags);
 
 /**
  * Manages registration and lifetime of the modded content


### PR DESCRIPTION
In the `IsDescriptorFilteredOut()` function, add additional checks to filter out item descriptors depending on their resource form. Without this change, the `IncludeNonSolid` flag does absolutely nothing. Also filter out any non-subclasses of `UFGItemDescriptor`, which shouldn't have been registered in the item registry to begin with.