### PR TITLE
Fix problems involving inexistent session settings

### DIFF
--- a/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsManager.cpp
+++ b/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsManager.cpp
@@ -146,6 +146,7 @@ FVariant USessionSettingsManager::StringToVariant(const FString& String) {
 UFGUserSettingApplyType* USessionSettingsManager::FindSessionSetting(const FString& strId) const {
 	UFGUserSettingApplyType* const* SessionSetting = SessionSettings.Find(strId);
 	if (!SessionSetting) {
+		UE_LOG(LogSatisfactoryModLoader, Error, TEXT("Could not find session setting '%s'"), *strId);
 		return nullptr;
 	}
 	return *SessionSetting;

--- a/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsManager.cpp
+++ b/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsManager.cpp
@@ -233,11 +233,11 @@ void USessionSettingsManager::ResetAllSettingsInCategory(TSubclassOf<UFGUserSett
 }
 
 bool USessionSettingsManager::GetBoolOptionValue(const FString& cvar) const {
-	return GetOptionValue(cvar, FVariant(false)).GetValue<bool>();
+	return GetOptionValue_Typed<bool>(cvar, false);
 }
 
 bool USessionSettingsManager::GetBoolUIDisplayValue(const FString& cvar) const {
-	return GetOptionDisplayValue(cvar, FVariant(false)).GetValue<bool>();
+	return GetOptionDisplayValue_Typed<bool>(cvar, false);
 }
 
 void USessionSettingsManager::SetBoolOptionValue(const FString& cvar, bool value) {
@@ -245,11 +245,11 @@ void USessionSettingsManager::SetBoolOptionValue(const FString& cvar, bool value
 }
 
 int32 USessionSettingsManager::GetIntOptionValue(const FString& cvar) const {
-	return GetOptionValue(cvar, FVariant(0)).GetValue<int32>();
+	return GetOptionValue_Typed<int32>(cvar, 0);
 }
 
 int32 USessionSettingsManager::GetIntUIDisplayValue(const FString& cvar) const {
-	return GetOptionDisplayValue(cvar, FVariant(0)).GetValue<int32>();
+	return GetOptionDisplayValue_Typed<int32>(cvar, 0);
 }
 
 void USessionSettingsManager::SetIntOptionValue(const FString& cvar, int32 newValue) {
@@ -257,11 +257,11 @@ void USessionSettingsManager::SetIntOptionValue(const FString& cvar, int32 newVa
 }
 
 float USessionSettingsManager::GetFloatOptionValue(const FString& cvar) const {
-	return GetOptionValue(cvar, FVariant(0)).GetValue<float>();
+	return GetOptionValue_Typed<float>(cvar, 0);
 }
 
 float USessionSettingsManager::GetFloatUIDisplayValue(const FString& cvar) const {
-	return GetOptionDisplayValue(cvar, FVariant(0)).GetValue<float>();
+	return GetOptionDisplayValue_Typed<float>(cvar, 0);
 }
 
 void USessionSettingsManager::SetFloatOptionValue(const FString& cvar, float newValue) {

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "FGOptionInterface.h"
-#include "FGPlayerState.h"
+#include "Templates/Identity.h"
 #include "Settings/FGUserSetting.h"
 #include "Settings/FGUserSettingCategory.h"
 #include "Subsystems/EngineSubsystem.h"
@@ -84,13 +84,13 @@ private:
 	 * function templates to explicitly specify the type argument T.
 	 */
 	template<typename T>
-	FORCEINLINE T GetOptionValue_Typed(const FString& cvar, typename TEnableIf<true, const T>::Type defaultValue) const
+	FORCEINLINE T GetOptionValue_Typed(const FString& cvar, TIdentity_T<const T> defaultValue) const
 	{
 		return GetOptionValue(cvar, FVariant(defaultValue)).GetValue<T>();
 	}
 
 	template<typename T>
-	FORCEINLINE T GetOptionDisplayValue_Typed(const FString& cvar, typename TEnableIf<true, const T>::Type defaultValue) const
+	FORCEINLINE T GetOptionDisplayValue_Typed(const FString& cvar, TIdentity_T<const T> defaultValue) const
 	{
 		return GetOptionDisplayValue(cvar, FVariant(defaultValue)).GetValue<T>();
 	}

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
@@ -74,6 +74,26 @@ private:
 	bool IsInMainMenu() const;
 	
 	void OnOptionUpdated(FString String, FVariant Value) const;
+
+	/*
+	 * Using (integer) literals for template argument deduction is troublesome
+	 * because the deduced template type is not visible by default. Given that
+	 * requiring callers to cast literals is hideous and error-prone, use some
+	 * funny template shenanigans to prevent template argument deduction using
+	 * the values passed as function arguments. This requires callers of these
+	 * function templates to explicitly specify the type argument T.
+	 */
+	template<typename T>
+	FORCEINLINE T GetOptionValue_Typed(const FString& cvar, typename TEnableIf<true, const T>::Type defaultValue) const
+	{
+		return GetOptionValue(cvar, FVariant(defaultValue)).GetValue<T>();
+	}
+
+	template<typename T>
+	FORCEINLINE T GetOptionDisplayValue_Typed(const FString& cvar, typename TEnableIf<true, const T>::Type defaultValue) const
+	{
+		return GetOptionDisplayValue(cvar, FVariant(defaultValue)).GetValue<T>();
+	}
 private:
 	UPROPERTY(Transient)
 	TMap<FString, UFGUserSettingApplyType*> SessionSettings;


### PR DESCRIPTION
When trying to retrieve the float value of a session setting that does not exist, the game crashes because SML asserts on something involving variant type traits:
```
Assertion failed: (Type == TVariantTraits<T>::GetType()) || ((TVariantTraits<T>::GetType() == EVariantTypes::UInt8) && (Type == EVariantTypes::Enum))
```
This is because the fallback value passed to the `FVariant` constructor template is a literal `0`, whose type is `int`:
```cpp
    return GetOptionValue(cvar, FVariant(0)).GetValue<float>();
                       /* This: ~~~~~~~~~^~ */
```
Using (integer) literals for template argument deduction is troublesome because the deduced template type is not visible by default. Given that requiring callers to cast literals is hideous and error-prone, use some funny template shenanigans to prevent template argument deduction using the values passed as function arguments. This requires callers of these function templates to explicitly specify the type argument `T`.

In addition to fixing the crashes, log an error when a session setting cannot be found. This is helpful to figure out why something isn't working, as the session settings manager would silently return 0 otherwise.

Yes, this approach is absolutely overkill: changing or casting the zero literals to the correct type would also fix this problem. However, this approach is more robust and future-proof: bugs that would cause crashes at runtime are now caught at compile time, and also prevents these bugs from reappearing in case someone adds support for more types of session settings in the future.

Note that the "set" functions are not affected by this bug, as they do not have a literal fallback value. Instead, they use `FVariant(value)` where `value` is a function parameter. So, template argument deduction works as long as the function signature has the correct type (always).
