### PR TITLE
NativeHookManager.h: Fix typo in function name

### DIFF
--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -270,9 +270,9 @@ public:
 		Scope(Args...);
 		for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
 		{
-			(*Handler)(Scope.getResult(), Args...);
+			(*Handler)(Scope.GetResult(), Args...);
 		}
-		return Scope.getResult();
+		return Scope.GetResult();
 	}
 
 	static void ApplyCallVoid(ArgumentTypes... Args)


### PR DESCRIPTION
Looks like the hook invoker for global functions has a typo which prevents hooking global functions with non-void return. There are two instances of `.getResult()` that should be `.GetResult()`.