### PR TITLE
fix: Drop duplicate entry in Alpakit C++ template deps

### DIFF
--- a/Mods/Alpakit/Templates/CPPAndBlueprintBlank/Source/PLUGIN_NAME/PLUGIN_NAME.Build.cs
+++ b/Mods/Alpakit/Templates/CPPAndBlueprintBlank/Source/PLUGIN_NAME/PLUGIN_NAME.Build.cs
@@ -40,8 +40,7 @@ public class PLUGIN_NAME : ModuleRules
 			//"TemplateSequence",
 			"NetCore",
 			"GameplayTags",
-			"Json", "JsonUtilities",
-			"AssetRegistry"
+			"Json", "JsonUtilities"
 		});
 
 		// FactoryGame plugins


### PR DESCRIPTION
The "AssetRegistry" dependency was listed multiple times in the list of dependencies. Keep only the first instance.