### PR TITLE
Replace deprecated sections in .ini files

### DIFF
--- a/Config/DefaultDeviceProfiles.ini
+++ b/Config/DefaultDeviceProfiles.ini
@@ -1,4 +1,4 @@
-[/Script/Engine.TextureLODSettings]
+[GlobalDefaults DeviceProfile]
 @TextureLODGroups=Group
 +TextureLODGroups=(Group=TEXTUREGROUP_Project01,MinLODSize=1,MaxLODSize=16384,LODBias=0,MinMagFilter=aniso,MipFilter=point,MipGenSettings=TMGS_SimpleAverage)
 +TextureLODGroups=(Group=TEXTUREGROUP_HierarchicalLOD,LODBias=0,LODBias_Smaller=-1,LODBias_Smallest=-1,NumStreamedMips=-1,MipGenSettings=TMGS_SimpleAverage,MinLODSize=1,MaxLODSize=4096,MaxLODSize_Smaller=-1,MaxLODSize_Smallest=-1,OptionalLODBias=0,OptionalMaxLODSize=4096,MinMagFilter="Aniso",MipFilter="Point")

--- a/Config/DefaultEditor.ini
+++ b/Config/DefaultEditor.ini
@@ -1,0 +1,2 @@
+[/Script/AdvancedPreviewScene.SharedProfiles]
+

--- a/Config/DefaultEditor.ini
+++ b/Config/DefaultEditor.ini
@@ -1,2 +1,0 @@
-[/Script/AdvancedPreviewScene.SharedProfiles]
-

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -50,7 +50,7 @@ LogWwiseResourceLoader=Error
 [EnumRemap]
 TEXTUREGROUP_Project01.DisplayName=UI Streamable
 
-[/Script/Engine.TextureLODSettings]
+[GlobalDefaults DeviceProfile]
 @TextureLODGroups=Group
 +TextureLODGroups=(Group=TEXTUREGROUP_Project01,MinLODSize=1,MaxLODSize=16384,LODBias=0,MinMagFilter=aniso,MipFilter=point,MipGenSettings=TMGS_SimpleAverage)
 


### PR DESCRIPTION
Just do as UE says:

    Found a deprecated ini section name in SomeFile.ini.
    Search for [/Script/Engine.TextureLODSettings] and
    replace with [GlobalDefaults DeviceProfile]