### PR TITLE
Fix for Session Settings not syncing

### DIFF
--- a/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsSubsystem.cpp
+++ b/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsSubsystem.cpp
@@ -40,6 +40,9 @@ ASessionSettingsSubsystem* ASessionSettingsSubsystem::Get(UWorld* World) {
 void ASessionSettingsSubsystem::OnSessionSettingUpdated(const FString StrID, FVariant value) {
 	if(HasAuthority()) {
 		Multicast_SessionSettingUpdated(StrID, USessionSettingsManager::VariantToString(value));
+		USessionSettingsManager* SessionSettingsManager = GetWorld()->GetSubsystem<USessionSettingsManager>();
+		check(SessionSettingsManager);
+		SerializedSettings = SessionSettingsManager->SerializeSettingsToString();
 	} else {
 		// We're a client, so we only have our own player controller
 		AFGPlayerController* PlayerController = Cast<AFGPlayerController>(GetWorld()->GetFirstPlayerController());

--- a/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsSubsystem.cpp
+++ b/Mods/SML/Source/SML/Private/SessionSettings/SessionSettingsSubsystem.cpp
@@ -2,10 +2,15 @@
 #include "FGGameMode.h"
 #include "FGPlayerController.h"
 #include "Subsystem/SubsystemActorManager.h"
-#include "SessionSettingsSubsystem.h"
+#include "Net/UnrealNetwork.h"
 
 ASessionSettingsSubsystem::ASessionSettingsSubsystem() {
 	ReplicationPolicy = ESubsystemReplicationPolicy::SpawnOnServer_Replicate;
+}
+
+void ASessionSettingsSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	DOREPLIFETIME(ThisClass, SerializedSettings);
 }
 
 void ASessionSettingsSubsystem::Init() {

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsManager.h
@@ -56,6 +56,8 @@ public:
 	void SubscribeToAllOptionUpdates(const FOnOptionUpdated& onOptionUpdatedDelegate);
 	void UnsubscribeToAllOptionUpdates(const FOnOptionUpdated& onOptionUpdatedDelegate);
 
+	TMap<FString, UFGUserSettingApplyType*> GetAllSessionSettings() { return SessionSettings; };
+
 	UFUNCTION(BlueprintCallable, Category = "Session Settings Manager")
 	void InitializeForMap(const TSoftObjectPtr<UWorld>& World, bool bAttemptPreserveValues);
 	

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
@@ -10,6 +10,7 @@ class SML_API ASessionSettingsSubsystem : public AModSubsystem {
 	GENERATED_BODY()
 public:
 	ASessionSettingsSubsystem();
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 	
 	virtual void Init() override;
 

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
@@ -10,11 +10,8 @@ class SML_API ASessionSettingsSubsystem : public AModSubsystem {
 	GENERATED_BODY()
 public:
 	ASessionSettingsSubsystem();
-	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 	
 	virtual void Init() override;
-
-	// TODO: Use this to sync the settings to the client on join
 
 	static ASessionSettingsSubsystem* Get(UWorld* World);
 
@@ -26,12 +23,6 @@ private:
 	void Multicast_SessionSettingUpdated(const FString& StrID, const FString& ValueString);
 
 	FOnOptionUpdated OnOptionUpdatedDelegate;
-
-	UPROPERTY(ReplicatedUsing = OnRep_SerializedSettings)
-	FString SerializedSettings;
-
-	UFUNCTION()
-	void OnRep_SerializedSettings();
 };
 
 UCLASS(NotBlueprintable)
@@ -43,6 +34,13 @@ public:
 
 	UFUNCTION(Server, Reliable, WithValidation)
 	void Server_RequestSessionSettingUpdate(const FString& SessionSettingName, const FString& ValueString);
+
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_RequestAllSessionSettings();
+
+	UFUNCTION(Client, Reliable, WithValidation)
+	void Client_SendSessionSetting(const FString& SessionSettingName, const FString& ValueString);
+
 private:
 	UPROPERTY(Replicated)
 	bool mForceNetField_USMLSessionSettingsRemoteCallObject;

--- a/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
+++ b/Mods/SML/Source/SML/Public/SessionSettings/SessionSettingsSubsystem.h
@@ -25,6 +25,12 @@ private:
 	void Multicast_SessionSettingUpdated(const FString& StrID, const FString& ValueString);
 
 	FOnOptionUpdated OnOptionUpdatedDelegate;
+
+	UPROPERTY(ReplicatedUsing = OnRep_SerializedSettings)
+	FString SerializedSettings;
+
+	UFUNCTION()
+	void OnRep_SerializedSettings();
 };
 
 UCLASS(NotBlueprintable)


### PR DESCRIPTION
Added Server and Client RPCs so a joining client can ask for existing Session Settings from the Server and the server can send them back.