### PR TITLE
NativeHookManager.h: Fix compile issue with Linux Server

### DIFF
--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -308,8 +308,8 @@ public:
 		if (!bHookInitialized)
 		{
 			bHookInitialized = true;
-			void* HookFunctionPointer = static_cast<void*>( GetApplyCall() );
-			RealFunctionAddress = FNativeHookManagerInternal::RegisterHookFunction( DebugSymbolName, {Callable, 0, 0}, NULL, HookFunctionPointer, (void**) &FunctionPtr );
+			void* HookFunctionPointer = reinterpret_cast<void*>( GetApplyCall() );
+			RealFunctionAddress = FNativeHookManagerInternal::RegisterHookFunction( DebugSymbolName, { reinterpret_cast<void*>(Callable), 0, 0}, NULL, HookFunctionPointer, (void**) &FunctionPtr );
 			THandlerLists<Handler, HandlerAfter>* HandlerLists = CreateHandlerLists<Handler, HandlerAfter>( RealFunctionAddress );
 
 			HandlersBefore = &HandlerLists->HandlersBefore;


### PR DESCRIPTION
I thought this was already merged or in a PR somewhere... i guess not.