### PR TITLE
Fix duplicates in access transformers

### DIFF
--- a/Mods/AccessTransformers/Source/AccessTransformers.ubtplugin/Hooking/AHookingEntrypoint.cs
+++ b/Mods/AccessTransformers/Source/AccessTransformers.ubtplugin/Hooking/AHookingEntrypoint.cs
@@ -20,10 +20,19 @@ public class AHookingEntrypoint
         Patch();
     }
     
+    private static bool _hasAppliedPatches;
+
     private static void Patch()
     {
+        // UHT can run multiple times in the same UBT process (for different targets for example)
+        // and Harmony does not check whether a patch for the same ID has already been applied
+        // resulting in the same patch being applied multiple times, causing duplicate code to be generated
+        if (_hasAppliedPatches)
+            return;
+
         Harmony harmony = new("AccessTransformers");
         harmony.PatchAll();
+        _hasAppliedPatches = true;
     }
 
     private static Assembly? CurrentDomain_AssemblyResolve(object? sender, ResolveEventArgs args)

--- a/Mods/AccessTransformers/Source/AccessTransformers.ubtplugin/Types/AccessTransformers.cs
+++ b/Mods/AccessTransformers/Source/AccessTransformers.ubtplugin/Types/AccessTransformers.cs
@@ -88,11 +88,20 @@ public static class AccessTransformers
         }
     }
 
-    public static readonly AccessTransformerTable<FriendAccessTransformer> FriendAccessTransformers = new();
-    public static readonly AccessTransformerTable<AccessorAccessTransformer> AccessorAccessTransformers = new();
+    private static AccessTransformerTable<FriendAccessTransformer> _friendAccessTransformers = new();
+    private static AccessTransformerTable<AccessorAccessTransformer> _accessorAccessTransformers = new();
+
+    public static AccessTransformerTable<FriendAccessTransformer> FriendAccessTransformers => _friendAccessTransformers;
+    public static AccessTransformerTable<AccessorAccessTransformer> AccessorAccessTransformers => _accessorAccessTransformers;
 
     public static void Load(UhtSession session)
     {
+        // UHT can run multiple times in the same UBT process (for different targets for example)
+        // but it should never run concurrently, so we only need to clean the previous state when
+        // starting a new UHT session.
+        // If UE ever makes changes that run UHT concurrently, replace this with per-UhtSession AccessTransformerTables
+        _friendAccessTransformers = new();
+        _accessorAccessTransformers = new();
         var availablePlugins = PluginsBase.EnumeratePlugins(new FileReference(session.ProjectFile!));
         foreach (var plugin in availablePlugins)
         {


### PR DESCRIPTION
Access transformers can randomly fail builds. Looking into this, the accessors generated by the build tool appear multiple times in the file:

![image](https://github.com/user-attachments/assets/40af706f-a80c-44b3-8248-655a81f87422)

While I'm not sure of the exact cause, I observed that InsertCodeForClass was being called multiple times, and the accessors in the list kept piling up. I end up fixing this by clearing the list when the AT gets rescanned and also filtering to entries that haven't been used. I am not sure if this is correct behavior, but it results in my mod building without issue (and I had Discord user `d4rkl0rd` test my patch as well).

Unanswered questions:
- How does this behave with multiple mods? How does this behave with multiple mods with the same AT?
  - I am relatively new to this scene so I am not able to answer how this will behave with multiple mods (as I don't have any other mods and my only mod doesn't use SML). **Please test this before merging!!!**
- What caused this behavior? Was it an engine update? Is it https://github.com/satisfactorymodding/SatisfactoryModLoader/commit/330dace8118dede3638b1521a3fd88c8b39d7cc8 (I haven't bisected to figure it out but this is the only recent change)?

Relevant conversation was in `#cpp-help` in the Satisfactory Modding Discord server: https://canary.discord.com/channels/555424930502541343/862002356626128907/1286817631923474504
