### PR TITLE
FGBuildable.cpp: Fix root component mobility

### DIFF
--- a/Source/FactoryGame/Private/Buildables/FGBuildable.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildable.cpp
@@ -184,6 +184,7 @@ AFGBuildable::AFGBuildable(const FObjectInitializer& ObjectInitializer) : Super(
 	this->NetDormancy = ENetDormancy::DORM_Initial;
 	this->NetCullDistanceSquared = 5625000000.0;
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
+	this->RootComponent->SetMobility(EComponentMobility::Static);
 }
 void AFGBuildable::Serialize(FArchive& ar){ Super::Serialize(ar); }
 void AFGBuildable::PostLoad(){ Super::PostLoad(); }


### PR DESCRIPTION
Looking at the game's binaries, the root component of buildables has to default to static mobility. Otherwise, pre-placed buildings do not work properly in the editor.

The pre-placed buildings in ExampleLevel should no longer be stuck at 0 (which is inside the starting cube), but the level needs to be resaved.