### PR TITLE
Add moar calls to Super functions

### DIFF
--- a/Source/FactoryGame/Private/AI/FGCreatureController.cpp
+++ b/Source/FactoryGame/Private/AI/FGCreatureController.cpp
@@ -25,8 +25,8 @@ void AFGCreatureController::OnPossess(APawn* InPawn){ }
 void AFGCreatureController::OnUnPossess(){ }
 FPathFollowingRequestResult AFGCreatureController::MoveTo(const FAIMoveRequest& MoveRequest, FNavPathSharedPtr* OutPath){ return FPathFollowingRequestResult(); }
 void AFGCreatureController::UpdateControlRotation(float DeltaTime, bool bUpdatePawn){ }
-void AFGCreatureController::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGCreatureController::Tick(float DeltaSeconds){ }
+void AFGCreatureController::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
+void AFGCreatureController::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGCreatureController::SetEnabled(bool enabled){ }
 bool AFGCreatureController::IsReadyToDespawn() const{ return bool(); }
 void AFGCreatureController::CreatureDied(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildable.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildable.cpp
@@ -188,8 +188,8 @@ AFGBuildable::AFGBuildable(const FObjectInitializer& ObjectInitializer) : Super(
 }
 void AFGBuildable::Serialize(FArchive& ar){ Super::Serialize(ar); }
 void AFGBuildable::PostLoad(){ Super::PostLoad(); }
-void AFGBuildable::BeginPlay(){ }
-void AFGBuildable::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildable::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildable::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildable::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildable::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildable::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableAttachmentMerger.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableAttachmentMerger.cpp
@@ -12,6 +12,6 @@ AFGBuildableAttachmentMerger::AFGBuildableAttachmentMerger() : Super() {
 	this->mFactoryTickFunction.bAllowTickOnDedicatedServer = true;
 	this->mFactoryTickFunction.TickInterval = 0.0;
 }
-void AFGBuildableAttachmentMerger::BeginPlay(){ }
+void AFGBuildableAttachmentMerger::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableAttachmentMerger::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableAttachmentMerger::Factory_Tick(float deltaTime){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableAttachmentSplitter.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableAttachmentSplitter.cpp
@@ -12,6 +12,6 @@ AFGBuildableAttachmentSplitter::AFGBuildableAttachmentSplitter() : Super() {
 	this->mFactoryTickFunction.bAllowTickOnDedicatedServer = true;
 	this->mFactoryTickFunction.TickInterval = 0.0;
 }
-void AFGBuildableAttachmentSplitter::BeginPlay(){ }
+void AFGBuildableAttachmentSplitter::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableAttachmentSplitter::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableAttachmentSplitter::Factory_Tick(float deltaTime){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableBlueprintDesigner.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableBlueprintDesigner.cpp
@@ -50,8 +50,8 @@ void AFGBuildableBlueprintDesigner::GetLifetimeReplicatedProps(TArray<FLifetimeP
 	DOREPLIFETIME(AFGBuildableBlueprintDesigner, mBuildables);
 	DOREPLIFETIME(AFGBuildableBlueprintDesigner, mCurrentRecordData);
 }
-void AFGBuildableBlueprintDesigner::BeginPlay(){ }
-void AFGBuildableBlueprintDesigner::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableBlueprintDesigner::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableBlueprintDesigner::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableBlueprintDesigner::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 bool AFGBuildableBlueprintDesigner::CanDismantle_Implementation() const{ return bool(); }
 void AFGBuildableBlueprintDesigner::GetChildDismantleActors_Implementation(TArray<AActor*>& out_ChildDismantleActors) const{ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCalendar.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCalendar.cpp
@@ -12,8 +12,8 @@ AFGBuildableCalendar::AFGBuildableCalendar() : Super() {
 	this->mSlotFillerItemClass = nullptr;
 	this->NetDormancy = ENetDormancy::DORM_Awake;
 }
-void AFGBuildableCalendar::BeginPlay(){ }
-void AFGBuildableCalendar::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableCalendar::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableCalendar::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableCalendar::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableCalendar, mReplicatedIndexMapping);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCheatFluidSink.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCheatFluidSink.cpp
@@ -2,8 +2,8 @@
 
 #include "Buildables/FGBuildableCheatFluidSink.h"
 
-void AFGBuildableCheatFluidSink::BeginPlay(){ }
-void AFGBuildableCheatFluidSink::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildableCheatFluidSink::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableCheatFluidSink::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableCheatFluidSink::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
 FFluidBox* AFGBuildableCheatFluidSink::GetFluidBox(){ return nullptr; }
 TArray< class UFGPipeConnectionComponent* > AFGBuildableCheatFluidSink::GetPipeConnections(){ return TArray<class UFGPipeConnectionComponent*>(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCheatFluidSpawner.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCheatFluidSpawner.cpp
@@ -11,8 +11,8 @@ AFGBuildableCheatFluidSpawner::AFGBuildableCheatFluidSpawner() : Super() {
 	this->mPressure = 0.0;
 	this->mOutputConnection = nullptr;
 }
-void AFGBuildableCheatFluidSpawner::BeginPlay(){ }
-void AFGBuildableCheatFluidSpawner::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildableCheatFluidSpawner::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableCheatFluidSpawner::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableCheatFluidSpawner::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableCheatFluidSpawner, mResourceType);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCheatItemSink.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCheatItemSink.cpp
@@ -7,7 +7,7 @@ AFGBuildableCheatItemSink::AFGBuildableCheatItemSink() : Super() {
 	this->mCurrentItemRate = 0.0;
 	this->mCurrentPeriodTime = 0.0;
 }
-void AFGBuildableCheatItemSink::BeginPlay(){ }
+void AFGBuildableCheatItemSink::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableCheatItemSink::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
 void AFGBuildableCheatItemSink::Factory_Tick(float dt){ }
 void AFGBuildableCheatItemSink::Factory_CollectInput_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCheatItemSpawner.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCheatItemSpawner.cpp
@@ -16,7 +16,7 @@ void AFGBuildableCheatItemSpawner::GetLifetimeReplicatedProps(TArray< FLifetimeP
 	DOREPLIFETIME(AFGBuildableCheatItemSpawner, mItemRateLimit);
 	DOREPLIFETIME(AFGBuildableCheatItemSpawner, mItemDescriptor);
 }
-void AFGBuildableCheatItemSpawner::BeginPlay(){ }
+void AFGBuildableCheatItemSpawner::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableCheatItemSpawner::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
 void AFGBuildableCheatItemSpawner::Factory_Tick(float dt){ }
 bool AFGBuildableCheatItemSpawner::Factory_PeekOutput_Implementation(const UFGFactoryConnectionComponent* connection, TArray<FInventoryItem>& out_items, TSubclassOf<UFGItemDescriptor> type) const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCircuitBridge.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCircuitBridge.cpp
@@ -10,8 +10,8 @@ void AFGBuildableCircuitBridge::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableCircuitBridge, mIsBridgeConnected);
 }
-void AFGBuildableCircuitBridge::BeginPlay(){ }
-void AFGBuildableCircuitBridge::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableCircuitBridge::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableCircuitBridge::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGBuildableCircuitBridge::IsBridgeConnected() const{ return bool(); }
 void AFGBuildableCircuitBridge::CalculateBridgeConnected(){ }
 int32 AFGBuildableCircuitBridge::GetCircuitID0() const{ return int32(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableCircuitSwitch.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableCircuitSwitch.cpp
@@ -9,7 +9,7 @@ AFGBuildableCircuitSwitch::AFGBuildableCircuitSwitch() : Super() {
 	this->mBuildingTag = TEXT("");
 	this->mInteractionRegisterPlayerWithCircuit = true;
 }
-void AFGBuildableCircuitSwitch::BeginPlay(){ }
+void AFGBuildableCircuitSwitch::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableCircuitSwitch::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableCircuitSwitch, mIsSwitchOn);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableControlPanelHost.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableControlPanelHost.cpp
@@ -6,7 +6,7 @@ AFGBuildableControlPanelHost::AFGBuildableControlPanelHost() : Super() {
 	this->mDownstreamConnection = nullptr;
 	this->mControlledBuildableType = nullptr;
 }
-void AFGBuildableControlPanelHost::BeginPlay(){ }
+void AFGBuildableControlPanelHost::BeginPlay(){ Super::BeginPlay(); }
 TArray< AFGBuildable* >& AFGBuildableControlPanelHost::GetControlledBuildables(TSubclassOf< AFGBuildable > outputType){ return *(new TArray< AFGBuildable* >); }
 void AFGBuildableControlPanelHost::OnCircuitsRebuilt(){ }
 void AFGBuildableControlPanelHost::SearchDownstreamCircuit(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableConveyorAttachment.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableConveyorAttachment.cpp
@@ -10,7 +10,7 @@ AFGBuildableConveyorAttachment::AFGBuildableConveyorAttachment() : Super() {
 	this->mHologramClass = AFGConveyorAttachmentHologram::StaticClass();
 	this->NetDormancy = ENetDormancy::DORM_DormantAll;
 }
-void AFGBuildableConveyorAttachment::BeginPlay(){ }
+void AFGBuildableConveyorAttachment::BeginPlay(){ Super::BeginPlay(); }
 bool AFGBuildableConveyorAttachment::ShouldShowCenterGuidelinesForHologram(const AFGHologram* hologram) const{ return bool(); }
 void AFGBuildableConveyorAttachment::Dismantle_Implementation(){ }
 AFGBuildableConveyorAttachmentLightweight::AFGBuildableConveyorAttachmentLightweight() : Super() {

--- a/Source/FactoryGame/Private/Buildables/FGBuildableConveyorBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableConveyorBase.cpp
@@ -47,10 +47,10 @@ void AFGBuildableConveyorBase::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGBuildableConveyorBase, mChainSegmentIndex);
 }
 void AFGBuildableConveyorBase::PreReplication(IRepChangedPropertyTracker& ChangedPropertyTracker){ }
-void AFGBuildableConveyorBase::BeginPlay(){ }
-void AFGBuildableConveyorBase::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildableConveyorBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableConveyorBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableConveyorBase::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGBuildableConveyorBase::Tick(float dt){ }
+void AFGBuildableConveyorBase::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildableConveyorBase::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableConveyorBase::UpdateUseState_Implementation( AFGCharacterPlayer* byCharacter, const FVector& atLocation,  UPrimitiveComponent* componentHit, FUseState& out_useState){ }
 void AFGBuildableConveyorBase::OnUse_Implementation( AFGCharacterPlayer* byCharacter, const FUseState& state){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableConveyorBelt.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableConveyorBelt.cpp
@@ -24,8 +24,8 @@ void AFGBuildableConveyorBelt::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableConveyorBelt, mSplineData);
 }
-void AFGBuildableConveyorBelt::BeginPlay(){ }
-void AFGBuildableConveyorBelt::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableConveyorBelt::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableConveyorBelt::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableConveyorBelt::GainedSignificance_Implementation(){ }
 void AFGBuildableConveyorBelt::LostSignificance_Implementation(){ }
 float AFGBuildableConveyorBelt::GetSignificanceRange(){ return float(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableConveyorLift.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableConveyorLift.cpp
@@ -35,7 +35,7 @@ void AFGBuildableConveyorLift::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGBuildableConveyorLift, mSnappedPassthroughs);
 	DOREPLIFETIME(AFGBuildableConveyorLift, mOpposingConnectionClearance);
 }
-void AFGBuildableConveyorLift::BeginPlay(){ }
+void AFGBuildableConveyorLift::BeginPlay(){ Super::BeginPlay(); }
 int32 AFGBuildableConveyorLift::GetDismantleRefundReturnsMultiplier() const{ return int32(); }
 bool AFGBuildableConveyorLift::ShouldShowCenterGuidelinesForHologram(const AFGHologram* hologram) const{ return bool(); }
 void AFGBuildableConveyorLift::Upgrade_Implementation(AActor* newActor){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableDockingStation.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableDockingStation.cpp
@@ -48,10 +48,10 @@ void AFGBuildableDockingStation::GetLifetimeReplicatedProps(TArray<FLifetimeProp
 	DOREPLIFETIME(AFGBuildableDockingStation, mMaximumStackTransferRate);
 }
 void AFGBuildableDockingStation::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildableDockingStation::BeginPlay(){ }
-void AFGBuildableDockingStation::Tick(float DeltaSeconds){ }
-void AFGBuildableDockingStation::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGBuildableDockingStation::Destroyed(){ }
+void AFGBuildableDockingStation::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableDockingStation::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGBuildableDockingStation::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildableDockingStation::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableDockingStation::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 float AFGBuildableDockingStation::GetSignificanceRange(){ return float(); }
 bool AFGBuildableDockingStation::DockActor( AActor* actor){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableDroneStation.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableDroneStation.cpp
@@ -65,8 +65,8 @@ void AFGBuildableDroneStation::GetLifetimeReplicatedProps(TArray<FLifetimeProper
 	DOREPLIFETIME(AFGBuildableDroneStation, mInfo);
 	DOREPLIFETIME(AFGBuildableDroneStation, mMapText);
 }
-void AFGBuildableDroneStation::BeginPlay(){ }
-void AFGBuildableDroneStation::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableDroneStation::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableDroneStation::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableDroneStation::Factory_Tick(float dt){ }
 void AFGBuildableDroneStation::Factory_TickProducing(float dt){ }
 void AFGBuildableDroneStation::Factory_CollectInput_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableFactory.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableFactory.cpp
@@ -76,9 +76,9 @@ void AFGBuildableFactory::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(AFGBuildableFactory, mIsOverclocked);
 	DOREPLIFETIME(AFGBuildableFactory, mIsAlienOverclocked);
 }
-void AFGBuildableFactory::BeginPlay(){ }
-void AFGBuildableFactory::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGBuildableFactory::Tick(float dt){ }
+void AFGBuildableFactory::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableFactory::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildableFactory::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildableFactory::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableFactory::GainedSignificance_Implementation(){ }
 void AFGBuildableFactory::LostSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableFactorySimpleProducer.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableFactorySimpleProducer.cpp
@@ -2,8 +2,8 @@
 
 #include "Buildables/FGBuildableFactorySimpleProducer.h"
 
-void AFGBuildableFactorySimpleProducer::BeginPlay(){ }
-void AFGBuildableFactorySimpleProducer::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildableFactorySimpleProducer::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableFactorySimpleProducer::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableFactorySimpleProducer::Factory_Tick(float dt){ }
 bool AFGBuildableFactorySimpleProducer::Factory_PeekOutput_Implementation(const  UFGFactoryConnectionComponent* connection, TArray< FInventoryItem >& out_items, TSubclassOf< UFGItemDescriptor > type) const{ return bool(); }
 bool AFGBuildableFactorySimpleProducer::Factory_GrabOutput_Implementation( UFGFactoryConnectionComponent* connection, FInventoryItem& out_item, float& out_OffsetBeyond, TSubclassOf< UFGItemDescriptor > type){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableFloodlight.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableFloodlight.cpp
@@ -7,6 +7,6 @@ void AFGBuildableFloodlight::GetLifetimeReplicatedProps(TArray< FLifetimePropert
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableFloodlight, mFixtureAngle);
 }
-void AFGBuildableFloodlight::BeginPlay(){ }
+void AFGBuildableFloodlight::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableFloodlight::SetFixtureAngle(int32 angle){ }
 const FName AFGBuildableFloodlight::FIXTURE_COMPONENT_NAME = FName();

--- a/Source/FactoryGame/Private/Buildables/FGBuildableFrackingActivator.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableFrackingActivator.cpp
@@ -19,7 +19,7 @@ void AFGBuildableFrackingActivator::GetLifetimeReplicatedProps(TArray<FLifetimeP
 }
 float AFGBuildableFrackingActivator::GetPotentialExtractionPerMinute() const{ return float(); }
 void AFGBuildableFrackingActivator::OnExtractorSet(){ }
-void AFGBuildableFrackingActivator::BeginPlay(){ }
+void AFGBuildableFrackingActivator::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableFrackingActivator::Factory_StartProducing(){ }
 void AFGBuildableFrackingActivator::Factory_TickProducing(float dt){ }
 void AFGBuildableFrackingActivator::Factory_StopProducing(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableFrackingExtractor.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableFrackingExtractor.cpp
@@ -6,7 +6,7 @@
 AFGBuildableFrackingExtractor::AFGBuildableFrackingExtractor() : Super() {
 
 }
-void AFGBuildableFrackingExtractor::BeginPlay(){ }
+void AFGBuildableFrackingExtractor::BeginPlay(){ Super::BeginPlay(); }
 bool AFGBuildableFrackingExtractor::Factory_HasPower() const{ return bool(); }
 bool AFGBuildableFrackingExtractor::CanProduce_Implementation() const{ return bool(); }
 void AFGBuildableFrackingExtractor::Factory_StartProducing(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorFuel.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorFuel.cpp
@@ -27,7 +27,7 @@ void AFGBuildableGeneratorFuel::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	DOREPLIFETIME(AFGBuildableGeneratorFuel, mCurrentFuelClass);
 }
 void AFGBuildableGeneratorFuel::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildableGeneratorFuel::BeginPlay(){ }
+void AFGBuildableGeneratorFuel::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableGeneratorFuel::PostLoad(){ Super::PostLoad(); }
 void AFGBuildableGeneratorFuel::Factory_Tick(float dt){ }
 bool AFGBuildableGeneratorFuel::IsValidFuel(TSubclassOf<  UFGItemDescriptor > resource) const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorGeoThermal.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorGeoThermal.cpp
@@ -12,8 +12,8 @@ void AFGBuildableGeneratorGeoThermal::GetLifetimeReplicatedProps(TArray<FLifetim
 	DOREPLIFETIME(AFGBuildableGeneratorGeoThermal, mMaxPowerProduction);
 	DOREPLIFETIME(AFGBuildableGeneratorGeoThermal, mVariablePowerProductionCycleOffset);
 }
-void AFGBuildableGeneratorGeoThermal::BeginPlay(){ }
-void AFGBuildableGeneratorGeoThermal::Destroyed(){ }
+void AFGBuildableGeneratorGeoThermal::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableGeneratorGeoThermal::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableGeneratorGeoThermal::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableGeneratorGeoThermal::SetExtractableResource(TScriptInterface<  IFGExtractableResourceInterface > extractableResource){ }
 void AFGBuildableGeneratorGeoThermal::Factory_Tick(float dt){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorNuclear.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableGeneratorNuclear.cpp
@@ -8,7 +8,7 @@ AFGBuildableGeneratorNuclear::AFGBuildableGeneratorNuclear() : Super() {
 	this->mCurrentGeneratorNuclearWarning = EGeneratorNuclearWarning::GNW_None;
 }
 void AFGBuildableGeneratorNuclear::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildableGeneratorNuclear::BeginPlay(){ }
+void AFGBuildableGeneratorNuclear::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableGeneratorNuclear::Factory_Tick(float dt){ }
 bool AFGBuildableGeneratorNuclear::CanStartPowerProduction_Implementation() const{ return bool(); }
 bool AFGBuildableGeneratorNuclear::CanLoadFuel() const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableJumppad.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableJumppad.cpp
@@ -44,8 +44,8 @@ FVector AFGBuildableJumppad::CalculateLaunchVelocity(const FVector& startLocatio
 const FTrajectoryData& AFGBuildableJumppad::ResimulateTrajectory(){ return *(new FTrajectoryData); }
 FTrajectoryData AFGBuildableJumppad::SimulateTrajectory(UWorld* pWorld, const FVector& StartLocation, const FVector& LaunchVector, float GravityMultiplier, AFGBuildableJumppad* pJumpPad){ return FTrajectoryData(); }
 void AFGBuildableJumppad::Launch(){ }
-void AFGBuildableJumppad::BeginPlay(){ }
-void AFGBuildableJumppad::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableJumppad::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableJumppad::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 float AFGBuildableJumppad::GetProductionProgress() const{ return float(); }
 bool AFGBuildableJumppad::CanProduce_Implementation() const{ return bool(); }
 EProductionStatus AFGBuildableJumppad::GetProductionIndicatorStatus() const{ return EProductionStatus(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableLadder.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableLadder.cpp
@@ -17,7 +17,7 @@ AFGBuildableLadder::AFGBuildableLadder() : Super() {
 	this->mFrontLadderComponent->SetupAttachment(RootComponent);
 	this->mBackLadderComponent->SetupAttachment(RootComponent);
 }
-void AFGBuildableLadder::BeginPlay(){ }
+void AFGBuildableLadder::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableLadder::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableLadder, mNumSegments);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableLightSource.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableLightSource.cpp
@@ -27,8 +27,8 @@ void AFGBuildableLightSource::GetLifetimeReplicatedProps(TArray< FLifetimeProper
 	DOREPLIFETIME(AFGBuildableLightSource, mHasPower);
 	DOREPLIFETIME(AFGBuildableLightSource, mIsDay);
 }
-void AFGBuildableLightSource::BeginPlay(){ }
-void AFGBuildableLightSource::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableLightSource::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableLightSource::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGBuildableLightSource::GetPoolHandleInitialState() const{ return bool(); }
 UFGFactoryClipboardSettings* AFGBuildableLightSource::CopySettings_Implementation(){ return nullptr; }
 bool AFGBuildableLightSource::PasteSettings_Implementation(UFGFactoryClipboardSettings* settings){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableMAM.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableMAM.cpp
@@ -2,8 +2,8 @@
 
 #include "Buildables/FGBuildableMAM.h"
 
-void AFGBuildableMAM::BeginPlay(){ }
-void AFGBuildableMAM::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableMAM::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableMAM::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableMAM::GainedSignificance_Implementation(){ }
 void AFGBuildableMAM::LostSignificance_Implementation(){ }
 void AFGBuildableMAM::GainedSignificance_Native(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableManufacturer.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableManufacturer.cpp
@@ -26,8 +26,8 @@ AFGBuildableManufacturer::AFGBuildableManufacturer() : Super() {
 	this->mCanChangeProductionBoost = true;
 	this->NetDormancy = ENetDormancy::DORM_Initial;
 }
-void AFGBuildableManufacturer::BeginPlay(){ }
-void AFGBuildableManufacturer::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableManufacturer::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableManufacturer::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGBuildableManufacturer::IsConfigured() const{ return bool(); }
 float AFGBuildableManufacturer::GetProductionCycleTime() const{ return float(); }
 float AFGBuildableManufacturer::GetDefaultProductionCycleTime() const{ return float(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableManufacturerVariablePower.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableManufacturerVariablePower.cpp
@@ -8,7 +8,7 @@ AFGBuildableManufacturerVariablePower::AFGBuildableManufacturerVariablePower() :
 	this->mPowerConsumptionCurve = nullptr;
 	this->mPowerConsumption = 0.1;
 }
-void AFGBuildableManufacturerVariablePower::BeginPlay(){ }
+void AFGBuildableManufacturerVariablePower::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableManufacturerVariablePower::Factory_StartProducing(){ }
 void AFGBuildableManufacturerVariablePower::Factory_TickProducing(float dt){ }
 void AFGBuildableManufacturerVariablePower::Factory_Tick(float dt){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePassthroughBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePassthroughBase.cpp
@@ -16,7 +16,7 @@ AFGBuildablePassthroughBase::AFGBuildablePassthroughBase() : Super() {
 	this->mClearanceThickness = 80.0;
 	this->mCostSegmentLength = 400.0;
 }
-void AFGBuildablePassthroughBase::BeginPlay(){ }
+void AFGBuildablePassthroughBase::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePassthroughBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePassthroughBase, mSnappedBuildingThickness);

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePassthroughPipeHyper.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePassthroughPipeHyper.cpp
@@ -10,7 +10,7 @@ AFGBuildablePassthroughPipeHyper::AFGBuildablePassthroughPipeHyper() : Super() {
 	this->mConnection0->SetupAttachment(RootComponent);
 	this->mConnection1->SetupAttachment(RootComponent);
 }
-void AFGBuildablePassthroughPipeHyper::BeginPlay(){ }
+void AFGBuildablePassthroughPipeHyper::BeginPlay(){ Super::BeginPlay(); }
 TArray<TPair<UFGPipeConnectionComponentBase*, float>> AFGBuildablePassthroughPipeHyper::GetPossibleConnectionsToTransitionThrough(AFGCharacterPlayer* charPlayer, UFGPipeConnectionComponentBase* connectionEnteredThrough) const{ return TArray<TPair<UFGPipeConnectionComponentBase*,float>>(); }
 EPipeHyperEnterResult AFGBuildablePassthroughPipeHyper::OnPipeEnterReal(AFGCharacterPlayer* charPlayer, UFGPipeConnectionComponentBase* connectionEnteredThrough, TStructOnScope<FFGPipeHyperBasePipeData>& outPipeData, const TStructOnScope<FFGPipeHyperBasePipeData>& predictionPipeData){ return EPipeHyperEnterResult(); }
 bool AFGBuildablePassthroughPipeHyper::FindDistanceClosestToWorldLocation(AFGCharacterPlayer* charPlayer, const FVector& worldLocation, const FVector& velocity, TStructOnScope<FFGPipeHyperBasePipeData>& out_pipeData, float& out_distance) const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeBase.cpp
@@ -26,8 +26,8 @@ void AFGBuildablePipeBase::GetLifetimeReplicatedProps(TArray< FLifetimeProperty 
 	DOREPLIFETIME(AFGBuildablePipeBase, mSplineData);
 	DOREPLIFETIME(AFGBuildablePipeBase, mSnappedPassthroughs);
 }
-void AFGBuildablePipeBase::BeginPlay(){ }
-void AFGBuildablePipeBase::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildablePipeBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePipeBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 int32 AFGBuildablePipeBase::GetDismantleRefundReturnsMultiplier() const{ return int32(); }
 bool AFGBuildablePipeBase::ShouldBeConsideredForBase_Implementation(){ return bool(); }
 void AFGBuildablePipeBase::GetClearanceData_Implementation(TArray< FFGClearanceData >& out_data) const{ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeHyper.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeHyper.cpp
@@ -11,7 +11,7 @@ AFGBuildablePipeHyper::AFGBuildablePipeHyper() : Super() {
 	this->mConnection0->SetupAttachment(RootComponent);
 	this->mConnection1->SetupAttachment(RootComponent);
 }
-void AFGBuildablePipeHyper::BeginPlay(){ }
+void AFGBuildablePipeHyper::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePipeHyper::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 TArray<TPair<UFGPipeConnectionComponentBase*, float>> AFGBuildablePipeHyper::GetPossibleConnectionsToTransitionThrough(AFGCharacterPlayer* charPlayer, UFGPipeConnectionComponentBase* connectionEnteredThrough) const{ return TArray<TPair<UFGPipeConnectionComponentBase*,float>>(); }
 EPipeHyperEnterResult AFGBuildablePipeHyper::OnPipeEnterReal(AFGCharacterPlayer* charPlayer, UFGPipeConnectionComponentBase* connectionEnteredThrough, TStructOnScope<FFGPipeHyperBasePipeData>& outPipeData, const TStructOnScope<FFGPipeHyperBasePipeData>& predictionPipeData){ return EPipeHyperEnterResult(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeHyperJunction.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeHyperJunction.cpp
@@ -8,7 +8,7 @@ AFGBuildablePipeHyperJunction::AFGBuildablePipeHyperJunction() : Super() {
 	this->DefaultConnectionInfo.ConnectionLabel = INVTEXT("");
 	this->DefaultConnectionInfo.bDefaultRoute = false;
 }
-void AFGBuildablePipeHyperJunction::BeginPlay(){ }
+void AFGBuildablePipeHyperJunction::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePipeHyperJunction::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePipeHyperJunction, ConnectionInfoList);

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeReservoir.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeReservoir.cpp
@@ -26,9 +26,9 @@ void AFGBuildablePipeReservoir::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePipeReservoir, mIndicatorData);
 }
-void AFGBuildablePipeReservoir::BeginPlay(){ }
-void AFGBuildablePipeReservoir::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGBuildablePipeReservoir::Tick(float dt){ }
+void AFGBuildablePipeReservoir::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePipeReservoir::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildablePipeReservoir::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildablePipeReservoir::Factory_Tick(float dt){ }
 FFluidBox* AFGBuildablePipeReservoir::GetFluidBox(){ return nullptr; }
 TArray< class UFGPipeConnectionComponent* > AFGBuildablePipeReservoir::GetPipeConnections(){ return TArray<class UFGPipeConnectionComponent*>(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipeline.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipeline.cpp
@@ -49,8 +49,8 @@ void AFGBuildablePipeline::GetLifetimeReplicatedProps(TArray< FLifetimeProperty 
 	DOREPLIFETIME(AFGBuildablePipeline, mFlowIndicator);
 	DOREPLIFETIME(AFGBuildablePipeline, mIndicatorData);
 }
-void AFGBuildablePipeline::BeginPlay(){ }
-void AFGBuildablePipeline::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildablePipeline::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePipeline::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildablePipeline::Factory_Tick(float dt){ }
 void AFGBuildablePipeline::PreUpgrade_Implementation(){ }
 void AFGBuildablePipeline::Upgrade_Implementation(AActor* newActor){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipelineAttachment.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipelineAttachment.cpp
@@ -27,8 +27,8 @@ AFGBuildablePipelineAttachment::AFGBuildablePipelineAttachment() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGBuildablePipelineAttachment::BeginPlay(){ }
-void AFGBuildablePipelineAttachment::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildablePipelineAttachment::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePipelineAttachment::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildablePipelineAttachment::Dismantle_Implementation(){ }
 bool AFGBuildablePipelineAttachment::ShouldShowCenterGuidelinesForHologram(const AFGHologram* hologram) const{ return bool(); }
 FFluidBox* AFGBuildablePipelineAttachment::GetFluidBox(){ return nullptr; }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePipelinePump.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePipelinePump.cpp
@@ -37,9 +37,9 @@ void AFGBuildablePipelinePump::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGBuildablePipelinePump, mUserFlowLimit);
 	DOREPLIFETIME(AFGBuildablePipelinePump, mIndicatorData);
 }
-void AFGBuildablePipelinePump::BeginPlay(){ }
+void AFGBuildablePipelinePump::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePipelinePump::EndPlay(const EEndPlayReason::Type EndPlayReason) { Super::EndPlay(EndPlayReason); }
-void AFGBuildablePipelinePump::Tick(float dt){ }
+void AFGBuildablePipelinePump::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildablePipelinePump::Factory_Tick(float dt){ }
 bool AFGBuildablePipelinePump::CanProduce_Implementation() const{ return bool(); }
 void AFGBuildablePipelinePump::OnBuildEffectFinished(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePixelSign.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePixelSign.cpp
@@ -2,8 +2,8 @@
 
 #include "Buildables/FGBuildablePixelSign.h"
 
-void AFGBuildablePixelSign::BeginPlay(){ }
-void AFGBuildablePixelSign::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildablePixelSign::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePixelSign::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGBuildablePixelSign::CanApplyDeferredColorToBuildable(FVector hitLocation, FVector hitNormal, TSubclassOf<  UFGFactoryCustomizationDescriptor_Swatch > swatch, APlayerController* playerController){ return bool(); }
 void AFGBuildablePixelSign::ApplyDeferredColorToBuildable(FVector hitLocation, TSubclassOf<  UFGFactoryCustomizationDescriptor_Swatch > swatch, APlayerController* playerController){ }
 bool AFGBuildablePixelSign::ShouldSave_Implementation() const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePole.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePole.cpp
@@ -23,7 +23,7 @@ void AFGBuildablePole::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 	DOREPLIFETIME(AFGBuildablePole, mHeight);
 	DOREPLIFETIME(AFGBuildablePole, mSelectedPoleVersion);
 }
-void AFGBuildablePole::BeginPlay(){ }
+void AFGBuildablePole::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePole::SetPoleHeight(float height){ }
 void AFGBuildablePole::SetupConnectionComponent(){ }
 TArray<struct FInstanceData> AFGBuildablePole::GetActorLightweightInstanceData_Implementation(){ return TArray<struct FInstanceData>(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePoleBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePoleBase.cpp
@@ -15,4 +15,4 @@ bool AFGBuildablePoleBase::ShouldBeConsideredForBase_Implementation(){ return bo
 bool AFGBuildablePoleBase::ShouldShowCenterGuidelinesForHologram(const AFGHologram* hologram) const{ return bool(); }
 struct FPoleHeightMesh AFGBuildablePoleBase::FindBestHeightMesh(float inHeight) const{ return FPoleHeightMesh(); }
 void AFGBuildablePoleBase::PostLoad(){ Super::PostLoad(); }
-void AFGBuildablePoleBase::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildablePoleBase::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePortal.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePortal.cpp
@@ -26,7 +26,7 @@ void AFGBuildablePortal::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >&
 	DOREPLIFETIME(AFGBuildablePortal, mCurrentHeatUpProgress);
 }
 void AFGBuildablePortal::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildablePortal::BeginPlay(){ }
+void AFGBuildablePortal::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePortal::Factory_Tick(float dt){ }
 void AFGBuildablePortal::Factory_CollectInput_Implementation(){ }
 bool AFGBuildablePortal::CanProduce_Implementation() const{ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePortalBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePortalBase.cpp
@@ -31,8 +31,8 @@ void AFGBuildablePortalBase::GetLifetimeReplicatedProps(TArray< FLifetimePropert
 	DOREPLIFETIME(AFGBuildablePortalBase, mIsPortalTraversable);
 	DOREPLIFETIME(AFGBuildablePortalBase, mPortalName);
 }
-void AFGBuildablePortalBase::BeginPlay(){ }
-void AFGBuildablePortalBase::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildablePortalBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePortalBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 float AFGBuildablePortalBase::GetProducingPowerConsumptionBase() const{ return float(); }
 void AFGBuildablePortalBase::Factory_Tick(float dt){ }
 void AFGBuildablePortalBase::Dismantle_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePowerPole.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePowerPole.cpp
@@ -17,7 +17,7 @@ AFGBuildablePowerPole::AFGBuildablePowerPole() : Super() {
 	this->mInteractionRegisterPlayerWithCircuit = true;
 	this->mMeshComponentProxy->SetupAttachment(RootComponent);
 }
-void AFGBuildablePowerPole::BeginPlay(){ }
+void AFGBuildablePowerPole::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePowerPole::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePowerPole, mHasPower);

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePowerStorage.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePowerStorage.cpp
@@ -20,7 +20,7 @@ AFGBuildablePowerStorage::AFGBuildablePowerStorage() : Super() {
 	this->mInteractionRegisterPlayerWithCircuit = true;
 	this->mMeshMesh->SetupAttachment(RootComponent);
 }
-void AFGBuildablePowerStorage::BeginPlay(){ }
+void AFGBuildablePowerStorage::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePowerStorage::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePowerStorage, mBatteryStatus);

--- a/Source/FactoryGame/Private/Buildables/FGBuildablePriorityPowerSwitch.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildablePriorityPowerSwitch.cpp
@@ -4,8 +4,8 @@
 #include "Net/UnrealNetwork.h"
 
 void AFGBuildablePriorityPowerSwitch::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
-void AFGBuildablePriorityPowerSwitch::BeginPlay(){ }
-void AFGBuildablePriorityPowerSwitch::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildablePriorityPowerSwitch::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePriorityPowerSwitch::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildablePriorityPowerSwitch::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePriorityPowerSwitch, mPriority);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRadarTower.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRadarTower.cpp
@@ -13,8 +13,8 @@ AFGBuildableRadarTower::AFGBuildableRadarTower() : Super() {
 	this->NetDormancy = ENetDormancy::DORM_Initial;
 	this->NetUpdateFrequency = 1.0;
 }
-void AFGBuildableRadarTower::BeginPlay(){ }
-void AFGBuildableRadarTower::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableRadarTower::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableRadarTower::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGBuildableRadarTower::AddAsRepresentation(){ return bool(); }
 bool AFGBuildableRadarTower::UpdateRepresentation(){ return bool(); }
 bool AFGBuildableRadarTower::RemoveAsRepresentation(){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRailroadBridge.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRailroadBridge.cpp
@@ -13,4 +13,4 @@ void AFGBuildableRailroadBridge::GetLifetimeReplicatedProps(TArray<FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableRailroadBridge, mSplineData);
 }
-void AFGBuildableRailroadBridge::BeginPlay(){ }
+void AFGBuildableRailroadBridge::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRailroadSignal.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRailroadSignal.cpp
@@ -22,9 +22,9 @@ void AFGBuildableRailroadSignal::GetLifetimeReplicatedProps(TArray< FLifetimePro
 	DOREPLIFETIME(AFGBuildableRailroadSignal, mBlockValidation);
 	DOREPLIFETIME(AFGBuildableRailroadSignal, mVisualState);
 }
-void AFGBuildableRailroadSignal::BeginPlay(){ }
-void AFGBuildableRailroadSignal::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGBuildableRailroadSignal::Destroyed(){ }
+void AFGBuildableRailroadSignal::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableRailroadSignal::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildableRailroadSignal::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableRailroadSignal::OnBuildEffectFinished(){ }
 void AFGBuildableRailroadSignal::OnBuildEffectActorFinished(){ }
 void AFGBuildableRailroadSignal::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRailroadStation.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRailroadStation.cpp
@@ -22,8 +22,8 @@ void AFGBuildableRailroadStation::GetLifetimeReplicatedProps(TArray< FLifetimePr
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableRailroadStation, mStationIdentifier);
 }
-void AFGBuildableRailroadStation::BeginPlay(){ }
-void AFGBuildableRailroadStation::Destroyed(){ }
+void AFGBuildableRailroadStation::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableRailroadStation::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableRailroadStation::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 bool AFGBuildableRailroadStation::CanDismantle_Implementation() const{ return bool(); }
 void AFGBuildableRailroadStation::GetDismantleDisqualifiers_Implementation(TArray<TSubclassOf<UFGConstructDisqualifier>>& out_dismantleDisqualifiers, const TArray<AActor*>& allSelectedActors) const{ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRailroadSwitchControl.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRailroadSwitchControl.cpp
@@ -18,8 +18,8 @@ void AFGBuildableRailroadSwitchControl::GetLifetimeReplicatedProps(TArray<FLifet
 	DOREPLIFETIME(AFGBuildableRailroadSwitchControl, mSwitchData);
 	DOREPLIFETIME(AFGBuildableRailroadSwitchControl, mVisualState);
 }
-void AFGBuildableRailroadSwitchControl::BeginPlay(){ }
-void AFGBuildableRailroadSwitchControl::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGBuildableRailroadSwitchControl::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableRailroadSwitchControl::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableRailroadSwitchControl::OnBuildEffectFinished(){ }
 void AFGBuildableRailroadSwitchControl::OnBuildEffectActorFinished(){ }
 void AFGBuildableRailroadSwitchControl::GainedSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRailroadTrack.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRailroadTrack.cpp
@@ -48,8 +48,8 @@ void AFGBuildableRailroadTrack::GetLifetimeReplicatedProps(TArray<FLifetimePrope
 	DOREPLIFETIME(AFGBuildableRailroadTrack, mSplineData);
 	DOREPLIFETIME(AFGBuildableRailroadTrack, mSignalBlockID);
 }
-void AFGBuildableRailroadTrack::BeginPlay(){ }
-void AFGBuildableRailroadTrack::Destroyed(){ }
+void AFGBuildableRailroadTrack::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableRailroadTrack::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableRailroadTrack::Dismantle_Implementation(){ }
 bool AFGBuildableRailroadTrack::CanDismantle_Implementation() const{ return bool(); }
 void AFGBuildableRailroadTrack::GetDismantleDependencies_Implementation(TArray<AActor*>& out_dismantleDependencies) const{ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableResourceExtractor.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableResourceExtractor.cpp
@@ -20,7 +20,7 @@ void AFGBuildableResourceExtractor::GetLifetimeReplicatedProps(TArray< FLifetime
 	DOREPLIFETIME(AFGBuildableResourceExtractor, mExtractStartupTimer);
 }
 void AFGBuildableResourceExtractor::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildableResourceExtractor::BeginPlay(){ }
+void AFGBuildableResourceExtractor::BeginPlay(){ Super::BeginPlay(); }
 bool AFGBuildableResourceExtractor::CanProduce_Implementation() const{ return bool(); }
 float AFGBuildableResourceExtractor::GetProductionCycleTime() const{ return float(); }
 float AFGBuildableResourceExtractor::GetProductionProgress() const{ return float(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableResourceExtractorBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableResourceExtractorBase.cpp
@@ -23,8 +23,8 @@ AFGBuildableResourceExtractorBase::AFGBuildableResourceExtractorBase() : Super()
 	this->mCanChangePotential = true;
 	this->mHologramClass = AFGResourceExtractorHologram::StaticClass();
 }
-void AFGBuildableResourceExtractorBase::BeginPlay(){ }
-void AFGBuildableResourceExtractorBase::Destroyed(){ }
+void AFGBuildableResourceExtractorBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableResourceExtractorBase::Destroyed(){ Super::Destroyed(); }
 bool AFGBuildableResourceExtractorBase::DisconnectExtractableResource(){ return bool(); }
 void AFGBuildableResourceExtractorBase::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableResourceExtractorBase::SetExtractableResource(TScriptInterface< IFGExtractableResourceInterface > extractableInterface){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableResourceSink.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableResourceSink.cpp
@@ -10,9 +10,9 @@ AFGBuildableResourceSink::AFGBuildableResourceSink() : Super() {
 	this->mProcessingTime = 3.0;
 	this->mProducingTimer = 0.0;
 }
-void AFGBuildableResourceSink::BeginPlay(){ }
-void AFGBuildableResourceSink::Tick(float dt){ }
-void AFGBuildableResourceSink::Destroyed(){ }
+void AFGBuildableResourceSink::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableResourceSink::Tick(float dt){ Super::Tick(dt); }
+void AFGBuildableResourceSink::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableResourceSink::Factory_CollectInput_Implementation(){ }
 bool AFGBuildableResourceSink::CanProduce_Implementation() const{ return bool(); }
 int32 AFGBuildableResourceSink::ClaimCoupons(int32 numCoupons){ return int32(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableResourceSinkShop.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableResourceSinkShop.cpp
@@ -8,6 +8,6 @@ AFGBuildableResourceSinkShop::AFGBuildableResourceSinkShop() : Super() {
 	this->mShopInventoryDefaultSize = 30;
 	this->mResourceSinkSubsystem = nullptr;
 }
-void AFGBuildableResourceSinkShop::BeginPlay(){ }
+void AFGBuildableResourceSinkShop::BeginPlay(){ Super::BeginPlay(); }
 bool AFGBuildableResourceSinkShop::CanInventoryFitPlannedPurchase(TArray< TSubclassOf<  UFGSchematic > > schematics) const{ return bool(); }
 bool AFGBuildableResourceSinkShop::PurchaseResourceSinkSchematics( UFGInventoryComponent* playerInventory, TArray< TSubclassOf<  UFGSchematic > > schematics){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableRoad.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableRoad.cpp
@@ -20,4 +20,4 @@ AFGBuildableRoad::AFGBuildableRoad() : Super() {
 	this->mConnection1->SetupAttachment(RootComponent);
 	this->mSplineComponent->SetupAttachment(RootComponent);
 }
-void AFGBuildableRoad::BeginPlay(){ }
+void AFGBuildableRoad::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableSignBase.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableSignBase.cpp
@@ -20,7 +20,7 @@ AFGBuildableSignBase::AFGBuildableSignBase() : Super() {
 	this->mFactoryTickFunction.TickInterval = 0.0;
 	this->mMeshComponentProxy->SetupAttachment(RootComponent);
 }
-void AFGBuildableSignBase::BeginPlay(){ }
+void AFGBuildableSignBase::BeginPlay(){ Super::BeginPlay(); }
 AFGBuildable* AFGBuildableSignBase::GetBuildable_Implementation(){ return nullptr; }
 TSubclassOf< UFGSignTypeDescriptor > AFGBuildableSignBase::GetSignTypeDescriptor_Implementation(){ return TSubclassOf<UFGSignTypeDescriptor>(); }
 FVector2D AFGBuildableSignBase::GetSignDimensions_Implementation(){ return FVector2D(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableSignSupport.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableSignSupport.cpp
@@ -19,7 +19,7 @@ void AFGBuildableSignSupport::GetLifetimeReplicatedProps(TArray< FLifetimeProper
 	DOREPLIFETIME(AFGBuildableSignSupport, mHeight);
 	DOREPLIFETIME(AFGBuildableSignSupport, mPoleMesh);
 }
-void AFGBuildableSignSupport::BeginPlay(){ }
+void AFGBuildableSignSupport::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableSignSupport::SetPoleScale(FVector2D poleScale){ }
 void AFGBuildableSignSupport::OnBuildEffectActorFinished(){ }
 TArray<struct FInstanceData> AFGBuildableSignSupport::GetActorLightweightInstanceData_Implementation(){ return TArray<struct FInstanceData>(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableSpaceElevator.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableSpaceElevator.cpp
@@ -40,7 +40,7 @@ float AFGBuildableSpaceElevator::GetActorFogOfWarRevealRadius(){ return float();
 ECompassViewDistance AFGBuildableSpaceElevator::GetActorCompassViewDistance(){ return ECompassViewDistance(); }
 void AFGBuildableSpaceElevator::SetActorCompassViewDistance(ECompassViewDistance compassViewDistance){ }
 UMaterialInterface* AFGBuildableSpaceElevator::GetActorRepresentationCompassMaterial(){ return nullptr; }
-void AFGBuildableSpaceElevator::BeginPlay(){ }
+void AFGBuildableSpaceElevator::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableSpaceElevator::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableSpaceElevator, mSpaceElevatorState);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableSplitterSmart.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableSplitterSmart.cpp
@@ -19,7 +19,7 @@ void AFGBuildableSplitterSmart::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableSplitterSmart, mSortRules);
 }
-void AFGBuildableSplitterSmart::BeginPlay(){ }
+void AFGBuildableSplitterSmart::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableSplitterSmart::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableSplitterSmart::GetDismantleRefund_Implementation(TArray< FInventoryStack >& out_refund, bool noBuildCostEnabled) const{ }
 void AFGBuildableSplitterSmart::Factory_Tick(float deltaTime){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableStorage.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableStorage.cpp
@@ -24,6 +24,6 @@ AFGBuildableStorage::AFGBuildableStorage() : Super() {
 	this->PrimaryActorTick.TickInterval = 0.0;
 	this->NetDormancy = ENetDormancy::DORM_Initial;
 }
-void AFGBuildableStorage::BeginPlay(){ }
+void AFGBuildableStorage::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableStorage::GetDismantleRefund_Implementation(TArray< FInventoryStack >& out_refund, bool noBuildCostEnabled) const{ }
 void AFGBuildableStorage::Factory_CollectInput_Implementation(){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableTradingPost.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableTradingPost.cpp
@@ -56,8 +56,8 @@ void AFGBuildableTradingPost::GetLifetimeReplicatedProps(TArray<FLifetimePropert
 	DOREPLIFETIME(AFGBuildableTradingPost, mCalendar);
 	DOREPLIFETIME(AFGBuildableTradingPost, mMiniGame);
 }
-void AFGBuildableTradingPost::BeginPlay(){ }
-void AFGBuildableTradingPost::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableTradingPost::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableTradingPost::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableTradingPost::GetChildDismantleActors_Implementation(TArray< AActor* >& out_ChildDismantleActors) const{ }
 bool AFGBuildableTradingPost::AddAsRepresentation(){ return bool(); }
 bool AFGBuildableTradingPost::UpdateRepresentation(){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableTrainPlatform.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableTrainPlatform.cpp
@@ -29,7 +29,7 @@ AFGBuildableTrainPlatform::AFGBuildableTrainPlatform() : Super() {
 	this->mPlatformConnection0->SetupAttachment(RootComponent);
 	this->mPlatformConnection1->SetupAttachment(RootComponent);
 }
-void AFGBuildableTrainPlatform::BeginPlay(){ }
+void AFGBuildableTrainPlatform::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableTrainPlatform::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableTrainPlatform, mRailroadTrack);

--- a/Source/FactoryGame/Private/Buildables/FGBuildableTrainPlatformCargo.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableTrainPlatformCargo.cpp
@@ -62,8 +62,8 @@ void AFGBuildableTrainPlatformCargo::GetLifetimeReplicatedProps(TArray<FLifetime
 	DOREPLIFETIME(AFGBuildableTrainPlatformCargo, mIsLoadUnloading);
 }
 void AFGBuildableTrainPlatformCargo::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildableTrainPlatformCargo::BeginPlay(){ }
-void AFGBuildableTrainPlatformCargo::Destroyed(){ }
+void AFGBuildableTrainPlatformCargo::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableTrainPlatformCargo::Destroyed(){ Super::Destroyed(); }
 bool AFGBuildableTrainPlatformCargo::Factory_PeekOutput_Implementation(const  UFGFactoryConnectionComponent* connection, TArray< FInventoryItem >& out_items, TSubclassOf< UFGItemDescriptor > type) const{ return bool(); }
 bool AFGBuildableTrainPlatformCargo::Factory_GrabOutput_Implementation( UFGFactoryConnectionComponent* connection, FInventoryItem& out_item, float& out_OffsetBeyond, TSubclassOf< UFGItemDescriptor > type){ return bool(); }
 bool AFGBuildableTrainPlatformCargo::Dock( AFGRailroadVehicle* actor){ return bool(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableWidgetSign.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableWidgetSign.cpp
@@ -30,8 +30,8 @@ void AFGBuildableWidgetSign::GetLifetimeReplicatedProps(TArray<FLifetimeProperty
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableWidgetSign, mDataVersion);
 }
-void AFGBuildableWidgetSign::BeginPlay(){ }
-void AFGBuildableWidgetSign::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableWidgetSign::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableWidgetSign::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableWidgetSign::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableWidgetSign::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGBuildableWidgetSign::OnConstruction(const FTransform& transform){ }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableWindTurbine.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableWindTurbine.cpp
@@ -2,4 +2,4 @@
 
 #include "Buildables/FGBuildableWindTurbine.h"
 
-void AFGBuildableWindTurbine::BeginPlay(){ }
+void AFGBuildableWindTurbine::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/Buildables/FGBuildableWire.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGBuildableWire.cpp
@@ -24,8 +24,8 @@ void AFGBuildableWire::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 	DOREPLIFETIME(AFGBuildableWire, mConnectionLocations);
 }
 void AFGBuildableWire::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGBuildableWire::BeginPlay(){ }
-void AFGBuildableWire::Destroyed(){ }
+void AFGBuildableWire::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableWire::Destroyed(){ Super::Destroyed(); }
 int32 AFGBuildableWire::GetDismantleRefundReturnsMultiplier() const{ return int32(); }
 bool AFGBuildableWire::ShouldBeConsideredForBase_Implementation(){ return bool(); }
 void AFGBuildableWire::StartIsLookedAtForDismantle_Implementation(AFGCharacterPlayer* byCharacter){ }

--- a/Source/FactoryGame/Private/Buildables/FGCentralStorageContainer.cpp
+++ b/Source/FactoryGame/Private/Buildables/FGCentralStorageContainer.cpp
@@ -29,14 +29,14 @@ float AFGCentralStorageContainer::GetActorFogOfWarRevealRadius(){ return float()
 ECompassViewDistance AFGCentralStorageContainer::GetActorCompassViewDistance(){ return ECompassViewDistance(); }
 void AFGCentralStorageContainer::SetActorCompassViewDistance(ECompassViewDistance compassViewDistance){ }
 UMaterialInterface* AFGCentralStorageContainer::GetActorRepresentationCompassMaterial(){ return nullptr; }
-void AFGCentralStorageContainer::BeginPlay(){ }
-void AFGCentralStorageContainer::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGCentralStorageContainer::BeginPlay(){ Super::BeginPlay(); }
+void AFGCentralStorageContainer::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGCentralStorageContainer::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGCentralStorageContainer, mUploadTimer);
 	DOREPLIFETIME(AFGCentralStorageContainer, mTimeToUpload);
 }
-void AFGCentralStorageContainer::Tick(float DeltaSeconds){ }
+void AFGCentralStorageContainer::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGCentralStorageContainer::Factory_Tick(float dt){ }
 void AFGCentralStorageContainer::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 bool AFGCentralStorageContainer::IsUploadingToCentralStorage(){ return bool(); }

--- a/Source/FactoryGame/Private/Creature/Enemy/FGFlyingBabyCrab.cpp
+++ b/Source/FactoryGame/Private/Creature/Enemy/FGFlyingBabyCrab.cpp
@@ -50,9 +50,9 @@ bool AFGFlyingBabyCrab::IsValidTarget(AActor* target) const{ return bool(); }
 void AFGFlyingBabyCrab::SetHomeLocation(const FVector& Location){ }
 void AFGFlyingBabyCrab::Explode(){ }
 void AFGFlyingBabyCrab::RegisterHostilePlayer( AFGCharacterPlayer* player){ }
-void AFGFlyingBabyCrab::BeginPlay(){ }
-void AFGFlyingBabyCrab::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGFlyingBabyCrab::Destroyed(){ }
+void AFGFlyingBabyCrab::BeginPlay(){ Super::BeginPlay(); }
+void AFGFlyingBabyCrab::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGFlyingBabyCrab::Destroyed(){ Super::Destroyed(); }
 void AFGFlyingBabyCrab::PostNetReceiveLocationAndRotation(){ }
 void AFGFlyingBabyCrab::OnClientSubsystemsValid(){ }
 void AFGFlyingBabyCrab::UpdateProjectileComponentSpeed(){ }

--- a/Source/FactoryGame/Private/Creature/FGAttachedLootComponent.cpp
+++ b/Source/FactoryGame/Private/Creature/FGAttachedLootComponent.cpp
@@ -5,8 +5,8 @@
 UFGAttachedLootComponent::UFGAttachedLootComponent() : Super() {
 	this->mAttachedItemPickup = nullptr;
 }
-void UFGAttachedLootComponent::BeginPlay(){ }
-void UFGAttachedLootComponent::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGAttachedLootComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGAttachedLootComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGAttachedLootComponent::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void UFGAttachedLootComponent::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void UFGAttachedLootComponent::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Creature/FGCreature.cpp
+++ b/Source/FactoryGame/Private/Creature/FGCreature.cpp
@@ -78,8 +78,8 @@ void AFGCreature::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLif
 	DOREPLIFETIME(AFGCreature, mIsEnabled);
 	DOREPLIFETIME(AFGCreature, mIsStunned);
 }
-void AFGCreature::BeginPlay(){ }
-void AFGCreature::Tick(float DeltaSeconds){ }
+void AFGCreature::BeginPlay(){ Super::BeginPlay(); }
+void AFGCreature::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGCreature::PreInitializeComponents(){ Super::PreInitializeComponents(); }
 void AFGCreature::PostInitializeComponents(){ Super::PostInitializeComponents(); }
 void AFGCreature::OnConstruction(const FTransform& Transform){ }

--- a/Source/FactoryGame/Private/Creature/FGCreatureMovementComponent.cpp
+++ b/Source/FactoryGame/Private/Creature/FGCreatureMovementComponent.cpp
@@ -2,7 +2,7 @@
 
 #include "Creature/FGCreatureMovementComponent.h"
 
-void UFGCreatureMovementComponent::BeginPlay(){ }
+void UFGCreatureMovementComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGCreatureMovementComponent::OnCharacterStuckInGeometry(const FHitResult* Hit){ }
 void UFGCreatureMovementComponent::OnMovementModeChanged(EMovementMode PreviousMovementMode, uint8 PreviousCustomMode){ }
 bool UFGCreatureMovementComponent::ResolvePenetrationImpl(const FVector& Adjustment, const FHitResult& Hit, const FQuat& NewRotation){ return bool(); }

--- a/Source/FactoryGame/Private/Creature/FGCreatureSpawner.cpp
+++ b/Source/FactoryGame/Private/Creature/FGCreatureSpawner.cpp
@@ -37,9 +37,9 @@ AFGCreatureSpawner::AFGCreatureSpawner() : Super() {
 	this->SpawnCollisionHandlingMethod = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButDontSpawnIfColliding;
 	this->RootComponent = mCapsuleComponent;
 }
-void AFGCreatureSpawner::BeginPlay(){ }
-void AFGCreatureSpawner::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGCreatureSpawner::Tick(float DeltaSeconds){ }
+void AFGCreatureSpawner::BeginPlay(){ Super::BeginPlay(); }
+void AFGCreatureSpawner::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGCreatureSpawner::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGCreatureSpawner::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGCreatureSpawner::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGCreatureSpawner::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Environment/FGGasPillarDesctructionActor.cpp
+++ b/Source/FactoryGame/Private/Environment/FGGasPillarDesctructionActor.cpp
@@ -10,5 +10,5 @@ AFGGasPillarDesctructionActor::AFGGasPillarDesctructionActor() : Super() {
 	this->mForceLocation = FVector::ZeroVector;
 	this->RootComponent = mGeometryCollectionComponent;
 }
-void AFGGasPillarDesctructionActor::BeginPlay(){ }
+void AFGGasPillarDesctructionActor::BeginPlay(){ Super::BeginPlay(); }
 void AFGGasPillarDesctructionActor::SetDestructionInfo(float dmgScale, const FVector& dmgLocation){ }

--- a/Source/FactoryGame/Private/Environment/FGRiver.cpp
+++ b/Source/FactoryGame/Private/Environment/FGRiver.cpp
@@ -8,7 +8,7 @@ void AFGRiver::OnSelected(UObject* Object){ }
 void AFGRiver::ReDraw(){ }
 void AFGRiver::DrawDebugData(){ }
 void AFGRiver::StopDrawDebugData(){ }
-void AFGRiver::Destroyed(){ }
+void AFGRiver::Destroyed(){ Super::Destroyed(); }
 void AFGRiver::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent){ Super::PostEditChangeProperty(PropertyChangedEvent); }
 #endif 
 #if WITH_EDITOR
@@ -43,8 +43,8 @@ AFGRiver::AFGRiver() : Super() {
 	this->PrimaryActorTick.TickInterval = 0.0;
 	this->RootComponent = mSplineComponent;
 }
-void AFGRiver::BeginPlay(){ }
-void AFGRiver::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGRiver::BeginPlay(){ Super::BeginPlay(); }
+void AFGRiver::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGRiver::OnConstruction(const FTransform & Transform){ }
 void AFGRiver::FixupSplinePoints(){ }
 void AFGRiver::ConstructMesh(){ }
@@ -52,5 +52,5 @@ void AFGRiver::ConstructVolumes(){ }
 void AFGRiver::SetupMaterialValues(UMaterialInstanceDynamic* Material){ }
 void AFGRiver::ApplyVertexColors(TArray<USplineMeshComponent*>& MeshComponents){ }
 void AFGRiver::HandlePush(float DeltaTime, ACharacter* Actor){ }
-void AFGRiver::Tick(float DeltaTime){ }
+void AFGRiver::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGRiver::OnBoxBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult){ }

--- a/Source/FactoryGame/Private/Environment/FGWaterfall.cpp
+++ b/Source/FactoryGame/Private/Environment/FGWaterfall.cpp
@@ -11,5 +11,5 @@ AFGWaterfall::AFGWaterfall() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGWaterfall::BeginPlay(){ }
-void AFGWaterfall::Tick(float DeltaTime){ }
+void AFGWaterfall::BeginPlay(){ Super::BeginPlay(); }
+void AFGWaterfall::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/Equipment/BoomBox/FGEquipmentBoomBox.cpp
+++ b/Source/FactoryGame/Private/Equipment/BoomBox/FGEquipmentBoomBox.cpp
@@ -11,8 +11,8 @@ void AFGEquipmentBoomBox::WasEquipped_Implementation(){ }
 void AFGEquipmentBoomBox::WasUnEquipped_Implementation(){ }
 void AFGEquipmentBoomBox::WasRemovedFromSlot_Implementation(){ }
 void AFGEquipmentBoomBox::WasSlottedIn_Implementation( AFGCharacterPlayer* holder){ }
-void AFGEquipmentBoomBox::BeginPlay(){ }
-void AFGEquipmentBoomBox::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGEquipmentBoomBox::BeginPlay(){ Super::BeginPlay(); }
+void AFGEquipmentBoomBox::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGEquipmentBoomBox::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGEquipmentBoomBox, mBoomBoxPlayer);

--- a/Source/FactoryGame/Private/Equipment/FGBuildGun.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGBuildGun.cpp
@@ -73,8 +73,8 @@ void AFGBuildGun::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLif
 	DOREPLIFETIME(AFGBuildGun, mStates);
 	DOREPLIFETIME(AFGBuildGun, mCurrentBuildGunMode);
 }
-void AFGBuildGun::BeginPlay(){ }
-void AFGBuildGun::Tick(float dt){ }
+void AFGBuildGun::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildGun::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildGun::Equip( AFGCharacterPlayer* character){ }
 void AFGBuildGun::UnEquip(){ }
 void AFGBuildGun::OnInteractWidgetAddedOrRemoved(UFGInteractWidget* widget, bool added){ }

--- a/Source/FactoryGame/Private/Equipment/FGChainsaw.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGChainsaw.cpp
@@ -19,7 +19,7 @@ AFGChainsaw::AFGChainsaw() : Super() {
 	this->mDefaultEquipmentActions = 1;
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 }
-void AFGChainsaw::Tick(float dt){ }
+void AFGChainsaw::Tick(float dt){ Super::Tick(dt); }
 void AFGChainsaw::LoadFromItemState_Implementation(const FFGDynamicStruct& itemState){ }
 FFGDynamicStruct AFGChainsaw::SaveToItemState_Implementation() const{ return FFGDynamicStruct(); }
 void AFGChainsaw::DisableEquipment(){ }

--- a/Source/FactoryGame/Private/Equipment/FGDowsingStick.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGDowsingStick.cpp
@@ -5,4 +5,4 @@
 AFGDowsingStick::AFGDowsingStick() : Super() {
 	this->mNumVolumesPerTick = 20;
 }
-void AFGDowsingStick::Tick(float DeltaSeconds){ }
+void AFGDowsingStick::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }

--- a/Source/FactoryGame/Private/Equipment/FGEquipment.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGEquipment.cpp
@@ -55,8 +55,8 @@ void AFGEquipment::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLi
 }
 void AFGEquipment::PreReplication(IRepChangedPropertyTracker & ChangedPropertyTracker){ }
 void AFGEquipment::OnRep_AttachmentReplication(){ }
-void AFGEquipment::BeginPlay(){ }
-void AFGEquipment::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGEquipment::BeginPlay(){ Super::BeginPlay(); }
+void AFGEquipment::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGEquipment::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGEquipment::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGEquipment::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Equipment/FGEquipmentDecoration.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGEquipmentDecoration.cpp
@@ -7,7 +7,7 @@ AFGEquipmentDecoration::AFGEquipmentDecoration() : Super() {
 	this->mArmAnimation = EArmEquipment::AE_Generic1Hand;
 	this->mDefaultEquipmentActions = 1;
 }
-void AFGEquipmentDecoration::Tick(float DeltaSeconds){ }
+void AFGEquipmentDecoration::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGEquipmentDecoration::OnPrimaryFirePressed(){ }
 void AFGEquipmentDecoration::Server_PrimaryFire_Implementation(){ }
 bool AFGEquipmentDecoration::Server_PrimaryFire_Validate(){ return bool(); }

--- a/Source/FactoryGame/Private/Equipment/FGEquipmentZipline.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGEquipmentZipline.cpp
@@ -23,7 +23,7 @@ void AFGEquipmentZipline::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGEquipmentZipline, mWantToGrab);
 }
-void AFGEquipmentZipline::Tick(float delta){ }
+void AFGEquipmentZipline::Tick(float delta){ Super::Tick(delta); }
 void AFGEquipmentZipline::AddEquipmentActionBindings(){ }
 void AFGEquipmentZipline::UnEquip(){ }
 void AFGEquipmentZipline::DoDrop(){ }

--- a/Source/FactoryGame/Private/Equipment/FGGasMask.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGGasMask.cpp
@@ -12,7 +12,7 @@ AFGGasMask::AFGGasMask() : Super() {
 void AFGGasMask::UnEquip(){ }
 FFGDynamicStruct AFGGasMask::SaveToItemState_Implementation() const{ return FFGDynamicStruct(); }
 void AFGGasMask::LoadFromItemState_Implementation(const FFGDynamicStruct& itemState){ }
-void AFGGasMask::Tick(const float deltaTime){ }
+void AFGGasMask::Tick(const float deltaTime){ Super::Tick(deltaTime); }
 float AFGGasMask::AdjustDamage_Implementation(const float damageAmount, const  UDamageType* damageType,  AController* instigatedBy, AActor* damageCauser){ return float(); }
 void AFGGasMask::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);

--- a/Source/FactoryGame/Private/Equipment/FGGolfCartDispenser.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGGolfCartDispenser.cpp
@@ -11,7 +11,7 @@ AFGGolfCartDispenser::AFGGolfCartDispenser() : Super() {
 	this->mArmAnimation = EArmEquipment::AE_PortableMiner;
 	this->mDefaultEquipmentActions = 1;
 }
-void AFGGolfCartDispenser::BeginPlay(){ }
+void AFGGolfCartDispenser::BeginPlay(){ Super::BeginPlay(); }
 void AFGGolfCartDispenser::SetMaterial( UMaterialInterface* material){ }
 void AFGGolfCartDispenser::SpawnGolfCart(){ }
 void AFGGolfCartDispenser::HandleDefaultEquipmentActionEvent(EDefaultEquipmentAction action, EDefaultEquipmentActionEvent actionEvent){ }

--- a/Source/FactoryGame/Private/Equipment/FGHookshot.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGHookshot.cpp
@@ -14,12 +14,12 @@ AFGHookshot::AFGHookshot() : Super() {
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
 	this->mHookshotAudio->SetupAttachment(RootComponent);
 }
-void AFGHookshot::BeginPlay(){ }
+void AFGHookshot::BeginPlay(){ Super::BeginPlay(); }
 void AFGHookshot::OnPrimaryFirePressed(){ }
 void AFGHookshot::OnSecondaryFirePressed(){ }
 void AFGHookshot::Equip( AFGCharacterPlayer* character){ }
 void AFGHookshot::UnEquip(){ }
-void AFGHookshot::Tick(float deltaTime){ }
+void AFGHookshot::Tick(float deltaTime){ Super::Tick(deltaTime); }
 void AFGHookshot::WireDetach(){ }
 void AFGHookshot::AddEquipmentActionBindings(){ }
 void AFGHookshot::MoveAudioSourceInFrontOfPlayer(){ }

--- a/Source/FactoryGame/Private/Equipment/FGHoverPack.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGHoverPack.cpp
@@ -51,8 +51,8 @@ void AFGHoverPack::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLife
 	DOREPLIFETIME(AFGHoverPack, mCurrentConnectionLocation);
 	DOREPLIFETIME(AFGHoverPack, mCurrentRailroadTrack);
 }
-void AFGHoverPack::BeginPlay(){ }
-void AFGHoverPack::Tick(float deltaTime){ }
+void AFGHoverPack::BeginPlay(){ Super::BeginPlay(); }
+void AFGHoverPack::Tick(float deltaTime){ Super::Tick(deltaTime); }
 void AFGHoverPack::UnEquip(){ }
 void AFGHoverPack::OnCharacterMovementModeChanged(EMovementMode PreviousMovementMode, uint8 PreviousCustomMode, EMovementMode NewMovementMode, uint8 NewCustomMode){ }
 void AFGHoverPack::AddEquipmentActionBindings(){ }

--- a/Source/FactoryGame/Private/Equipment/FGJetPack.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGJetPack.cpp
@@ -21,7 +21,7 @@ void AFGJetPack::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLife
 	DOREPLIFETIME(AFGJetPack, mSelectedFuelType);
 	DOREPLIFETIME(AFGJetPack, mCurrentFuelType);
 }
-void AFGJetPack::Tick(const float deltaTime){ }
+void AFGJetPack::Tick(const float deltaTime){ Super::Tick(deltaTime); }
 void AFGJetPack::LoadFromItemState_Implementation(const FFGDynamicStruct& itemState){ }
 FFGDynamicStruct AFGJetPack::SaveToItemState_Implementation() const{ return FFGDynamicStruct(); }
 void AFGJetPack::DisableEquipment(){ }

--- a/Source/FactoryGame/Private/Equipment/FGObjectScanner.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGObjectScanner.cpp
@@ -27,8 +27,8 @@ AFGObjectScanner::AFGObjectScanner() : Super() {
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 	this->mScannerSkeletalMesh->SetupAttachment(RootComponent);
 }
-void AFGObjectScanner::BeginPlay(){ }
-void AFGObjectScanner::Tick(float deltaTime){ }
+void AFGObjectScanner::BeginPlay(){ Super::BeginPlay(); }
+void AFGObjectScanner::Tick(float deltaTime){ Super::Tick(deltaTime); }
 void AFGObjectScanner::GetLifetimeReplicatedProps(TArray< FLifetimeProperty > & OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGObjectScanner, mClosestObject);

--- a/Source/FactoryGame/Private/Equipment/FGParachute.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGParachute.cpp
@@ -14,7 +14,7 @@ void AFGParachute::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLi
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGParachute, mIsDeployed);
 }
-void AFGParachute::Tick(float DeltaSeconds){ }
+void AFGParachute::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGParachute::UnEquip(){ }
 void AFGParachute::Input_Deploy(const FInputActionValue& actionValue){ }
 void AFGParachute::Input_UnDeploy(const FInputActionValue& actionValue){ }

--- a/Source/FactoryGame/Private/Equipment/FGPortableMinerDispenser.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGPortableMinerDispenser.cpp
@@ -12,7 +12,7 @@ AFGPortableMinerDispenser::AFGPortableMinerDispenser() : Super() {
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 	this->mHologramMeshComponent->SetupAttachment(RootComponent);
 }
-void AFGPortableMinerDispenser::Tick(float DeltaSeconds){ }
+void AFGPortableMinerDispenser::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGPortableMinerDispenser::UnEquip(){ }
 void AFGPortableMinerDispenser::HandleDefaultEquipmentActionEvent(EDefaultEquipmentAction action, EDefaultEquipmentActionEvent actionEvent){ }
 bool AFGPortableMinerDispenser::TraceForPortableMinerPlacementLocation(FVector& out_Location) const{ return bool(); }

--- a/Source/FactoryGame/Private/Equipment/FGResourceMiner.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGResourceMiner.cpp
@@ -18,7 +18,7 @@ void AFGResourceMiner::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGResourceMiner, mActiveResourceNode);
 }
-void AFGResourceMiner::Tick(float DeltaSeconds){ }
+void AFGResourceMiner::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGResourceMiner::UnEquip(){ }
 void AFGResourceMiner::HandleDefaultEquipmentActionEvent(EDefaultEquipmentAction action, EDefaultEquipmentActionEvent actionEvent){ }
 void AFGResourceMiner::ForceStopMining(){ }

--- a/Source/FactoryGame/Private/Equipment/FGResourceScanner.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGResourceScanner.cpp
@@ -15,8 +15,8 @@ AFGResourceScanner::AFGResourceScanner() : Super() {
 	this->mNeedsDefaultEquipmentMappingContext = false;
 	this->mArmAnimation = EArmEquipment::AE_ResourceScanner;
 }
-void AFGResourceScanner::BeginPlay(){ }
-void AFGResourceScanner::Tick(float dt){ }
+void AFGResourceScanner::BeginPlay(){ Super::BeginPlay(); }
+void AFGResourceScanner::Tick(float dt){ Super::Tick(dt); }
 void AFGResourceScanner::CreateResourceNodeRepresentations(const FNodeClusterData& cluster){ }
 TArray< TSubclassOf< UFGResourceDescriptor > > AFGResourceScanner::GetScannableResources() const{ return TArray<TSubclassOf<UFGResourceDescriptor> >(); }
 void AFGResourceScanner::SetResourceDescriptorToScanFor(TSubclassOf< UFGResourceDescriptor > inClass){ }

--- a/Source/FactoryGame/Private/Equipment/FGWeapon.cpp
+++ b/Source/FactoryGame/Private/Equipment/FGWeapon.cpp
@@ -39,8 +39,8 @@ void AFGWeapon::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifet
 	DOREPLIFETIME(AFGWeapon, mCurrentAmmunitionClass);
 	DOREPLIFETIME(AFGWeapon, mCurrentMagazineObject);
 }
-void AFGWeapon::BeginPlay(){ }
-void AFGWeapon::Tick(float DeltaSeconds){ }
+void AFGWeapon::BeginPlay(){ Super::BeginPlay(); }
+void AFGWeapon::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGWeapon::LoadFromItemState_Implementation(const FFGDynamicStruct& itemState){ }
 FFGDynamicStruct AFGWeapon::SaveToItemState_Implementation() const{ return FFGDynamicStruct(); }
 bool AFGWeapon::CanPickBestUsableActor_Implementation() const{ return bool(); }

--- a/Source/FactoryGame/Private/FGActorRepresentationManager.cpp
+++ b/Source/FactoryGame/Private/FGActorRepresentationManager.cpp
@@ -28,8 +28,8 @@ void AFGActorRepresentationManager::GetLifetimeReplicatedProps(TArray<FLifetimeP
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGActorRepresentationManager, mActorRepresentationReplicator);
 }
-void AFGActorRepresentationManager::BeginPlay(){ }
-void AFGActorRepresentationManager::Tick(float DeltaSeconds){ }
+void AFGActorRepresentationManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGActorRepresentationManager::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 UFGActorRepresentation* AFGActorRepresentationManager::CreateAndAddNewRepresentation(AActor* realActor, const bool isLocal , TSubclassOf<UFGActorRepresentation> representationClass){ return nullptr; }
 UFGActorRepresentation* AFGActorRepresentationManager::CreateNewRepresentationNoActor(FVector location,  UTexture2D* compassTexture, FLinearColor compassColor, float lifeSpan, bool shouldShowInCompass, bool shouldShowOnMap, ERepresentationType representationType , TSubclassOf<UFGActorRepresentation> representationClass){ return nullptr; }
 UFGActorRepresentation* AFGActorRepresentationManager::CreateAndAddNewRepresentationNoActor(FVector location,  UTexture2D* compassTexture, FLinearColor compassColor, float lifeSpan, bool shouldShowInCompass, bool shouldShowOnMap, ERepresentationType representationType , TSubclassOf<UFGActorRepresentation> representationClass){ return nullptr; }

--- a/Source/FactoryGame/Private/FGAmbientSoundSpline.cpp
+++ b/Source/FactoryGame/Private/FGAmbientSoundSpline.cpp
@@ -10,8 +10,8 @@ AFGAmbientSoundSpline::AFGAmbientSoundSpline() : Super() {
 	this->mSoundSpline->SetupAttachment(mSpline);
 	this->mSignificanceRange = 2000.0;
 }
-void AFGAmbientSoundSpline::BeginPlay(){ }
-void AFGAmbientSoundSpline::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGAmbientSoundSpline::BeginPlay(){ Super::BeginPlay(); }
+void AFGAmbientSoundSpline::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGAmbientSoundSpline::GainedSignificance_Implementation(){ }
 void AFGAmbientSoundSpline::LostSignificance_Implementation(){ }
 float AFGAmbientSoundSpline::GetSignificanceRange(){ return float(); }

--- a/Source/FactoryGame/Private/FGAmbientVolume.cpp
+++ b/Source/FactoryGame/Private/FGAmbientVolume.cpp
@@ -14,8 +14,8 @@ AFGAmbientVolume::AFGAmbientVolume() : Super() {
 	this->mSignificanceRange = 25000.0;
 	this->mAudioComponent->SetupAttachment(GetBrushComponent());
 }
-void AFGAmbientVolume::BeginPlay(){ }
-void AFGAmbientVolume::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGAmbientVolume::BeginPlay(){ Super::BeginPlay(); }
+void AFGAmbientVolume::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGAmbientVolume::GainedSignificance_Implementation(){ }
 void AFGAmbientVolume::LostSignificance_Implementation(){ }
 void AFGAmbientVolume::GainedSignificance_Native(){ }

--- a/Source/FactoryGame/Private/FGAtmosphereVolume.cpp
+++ b/Source/FactoryGame/Private/FGAtmosphereVolume.cpp
@@ -199,7 +199,7 @@ AFGAtmosphereVolume::AFGAtmosphereVolume() : Super() {
 	this->mEnableExpandGamut = false;
 	this->mEnableSceneColorTint = false;
 }
-void AFGAtmosphereVolume::BeginPlay(){ }
+void AFGAtmosphereVolume::BeginPlay(){ Super::BeginPlay(); }
 void AFGAtmosphereVolume::PostLoad(){ Super::PostLoad(); }
 void AFGAtmosphereVolume::PostRegisterAllComponents(){ }
 void AFGAtmosphereVolume::PostUnregisterAllComponents(void){ }

--- a/Source/FactoryGame/Private/FGAttentionPingActor.cpp
+++ b/Source/FactoryGame/Private/FGAttentionPingActor.cpp
@@ -19,7 +19,7 @@ AFGAttentionPingActor::AFGAttentionPingActor() : Super() {
 	this->SetReplicatingMovement(true);
 	this->bReplicates = true;
 }
-void AFGAttentionPingActor::BeginPlay(){ }
+void AFGAttentionPingActor::BeginPlay(){ Super::BeginPlay(); }
 void AFGAttentionPingActor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGAttentionPingActor, mOwningPlayerState);

--- a/Source/FactoryGame/Private/FGAudioVolumeSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGAudioVolumeSubsystem.cpp
@@ -14,9 +14,9 @@ AFGAudioVolumeSubsystem::AFGAudioVolumeSubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGAudioVolumeSubsystem::Tick(float dt){ }
-void AFGAudioVolumeSubsystem::BeginPlay(){ }
-void AFGAudioVolumeSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGAudioVolumeSubsystem::Tick(float dt){ Super::Tick(dt); }
+void AFGAudioVolumeSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGAudioVolumeSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGAudioVolumeSubsystem::ShouldUpdateWorld(UWorld* world) const{ return bool(); }
 void AFGAudioVolumeSubsystem::UpdateWorld(UWorld* world){ }
 float AFGAudioVolumeSubsystem::GetCloseDistance( AFGAmbientVolume* ambientVolume) const{ return float(); }

--- a/Source/FactoryGame/Private/FGBackgroundThread.cpp
+++ b/Source/FactoryGame/Private/FGBackgroundThread.cpp
@@ -51,7 +51,7 @@ void FFGBackgroundThread::DispatchToStatisticsSubsystem(){ }
 void APoolRoot::UpdateBuildingState( AFGBuildable* Building, int32 FlagsToSet){ }
 void APoolRoot::DisplayDebug(UCanvas* Canvas, const FDebugDisplayInfo& DebugDisplay, float& YL, float& YPos){ }
 void APoolRoot::SetFlag(AFGBuildable* Buildable,  int32 Flags){ }
-void APoolRoot::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void APoolRoot::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 UFGPoolableProxyComponentBase::UFGPoolableProxyComponentBase() : Super() {
 	this->bHiddenInGame = true;
 }

--- a/Source/FactoryGame/Private/FGBeacon.cpp
+++ b/Source/FactoryGame/Private/FGBeacon.cpp
@@ -2,4 +2,4 @@
 
 #include "FGBeacon.h"
 
-void AFGBeacon::BeginPlay(){ }
+void AFGBeacon::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGBlueprintProxy.cpp
+++ b/Source/FactoryGame/Private/FGBlueprintProxy.cpp
@@ -17,7 +17,7 @@ AFGBlueprintProxy::AFGBlueprintProxy() : Super() {
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 	this->mBoundingBox->SetupAttachment(RootComponent);
 }
-void AFGBlueprintProxy::BeginPlay(){ }
+void AFGBlueprintProxy::BeginPlay(){ Super::BeginPlay(); }
 void AFGBlueprintProxy::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBlueprintProxy, mBlueprintName);
@@ -25,7 +25,7 @@ void AFGBlueprintProxy::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& 
 	DOREPLIFETIME(AFGBlueprintProxy, mBuildables);
 	DOREPLIFETIME(AFGBlueprintProxy, mLightweightClassAndIndices);
 }
-void AFGBlueprintProxy::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBlueprintProxy::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBlueprintProxy::RegisterBuildable( AFGBuildable* buildable){ }
 void AFGBlueprintProxy::RegisterLightweightInstance(TSubclassOf<  AFGBuildable > buildableClass, int32 index){ }
 void AFGBlueprintProxy::UnregisterBuildable( AFGBuildable* buildable){ }

--- a/Source/FactoryGame/Private/FGBlueprintSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGBlueprintSubsystem.cpp
@@ -39,14 +39,14 @@ AFGBlueprintSubsystem::AFGBlueprintSubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGBlueprintSubsystem::BeginPlay(){ }
-void AFGBlueprintSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBlueprintSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGBlueprintSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBlueprintSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBlueprintSubsystem, mBlueprintCategoryRecords);
 	DOREPLIFETIME(AFGBlueprintSubsystem, mServerManifest);
 }
-void AFGBlueprintSubsystem::Tick(float deltaTime){ }
+void AFGBlueprintSubsystem::Tick(float deltaTime){ Super::Tick(deltaTime); }
 AFGBlueprintSubsystem* AFGBlueprintSubsystem::Get(UWorld* world){ return nullptr; }
 AFGBlueprintSubsystem* AFGBlueprintSubsystem::GetBlueprintSubsystem(UObject* worldContext){ return nullptr; }
 void AFGBlueprintSubsystem::Init(){ }

--- a/Source/FactoryGame/Private/FGBoomBoxPlayer.cpp
+++ b/Source/FactoryGame/Private/FGBoomBoxPlayer.cpp
@@ -100,7 +100,7 @@ TSubclassOf< class UFGTapeData > AFGBoomBoxPlayer::GetCurrentTape() const{ retur
 bool AFGBoomBoxPlayer::IsInEquipmentMode() const{ return bool(); }
 bool AFGBoomBoxPlayer::CanBePickedUp( AFGCharacterPlayer* byPlayer) const{ return bool(); }
 EBoomBoxPickupButtonState AFGBoomBoxPlayer::GetPickupButtonState(AFGCharacterPlayer* player){ return EBoomBoxPickupButtonState(); }
-void AFGBoomBoxPlayer::Tick(float DeltaTime){ }
+void AFGBoomBoxPlayer::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGBoomBoxPlayer::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBoomBoxPlayer, mMode);
@@ -139,8 +139,8 @@ void AFGBoomBoxPlayer::SetPlaybackStateFlag(EBoomBoxPlaybackStateBitfield flag, 
 void AFGBoomBoxPlayer::ApplyTurboBassGameplayEffects( AFGCharacterPlayer* character){ }
 void AFGBoomBoxPlayer::SetAudioVolumeLocally(float normalizedVolume, bool notifyListeners){ }
 UMaterialInterface* AFGBoomBoxPlayer::GetDefaultTapeMaterial(){ return nullptr; }
-void AFGBoomBoxPlayer::BeginPlay(){ }
-void AFGBoomBoxPlayer::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBoomBoxPlayer::BeginPlay(){ Super::BeginPlay(); }
+void AFGBoomBoxPlayer::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBoomBoxPlayer::OnPawnPossessed( APawn* pawn,  AController* controller){ }
 void AFGBoomBoxPlayer::OnceClientSubsystemsAreReady(){ }
 void AFGBoomBoxPlayer::SongFinished(EAkCallbackType cbType, UAkCallbackInfo* cbInfo){ }

--- a/Source/FactoryGame/Private/FGBuildEffectActor.cpp
+++ b/Source/FactoryGame/Private/FGBuildEffectActor.cpp
@@ -48,9 +48,9 @@ AFGBuildEffectActor::AFGBuildEffectActor() : Super() {
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
 	this->mSlicePlane->SetupAttachment(RootComponent);
 }
-void AFGBuildEffectActor::Tick(float DeltaTime){ }
-void AFGBuildEffectActor::BeginPlay(){ }
-void AFGBuildEffectActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildEffectActor::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
+void AFGBuildEffectActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildEffectActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildEffectActor::SetDismantle(bool State){ }
 void AFGBuildEffectActor::AddAbstractDataEntry(TSubclassOf< AFGBuildable > buildableClass, const FRuntimeBuildableInstanceData& runtimeData, UAbstractInstanceDataObject* InstanceData, int32 Index){ }
 void AFGBuildEffectActor::RemoveAbstractDataEntry(TSubclassOf< AFGBuildable > buildableClass, int32 index){ }

--- a/Source/FactoryGame/Private/FGBuildEffectSpline.cpp
+++ b/Source/FactoryGame/Private/FGBuildEffectSpline.cpp
@@ -12,6 +12,6 @@ AFGBuildEffectSpline::AFGBuildEffectSpline() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGBuildEffectSpline::BeginPlay(){ }
-void AFGBuildEffectSpline::Tick(float DeltaTime){ }
+void AFGBuildEffectSpline::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildEffectSpline::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGBuildEffectSpline::SetupAttachment( AFGPipeBuilderTrail* inAttachment){ }

--- a/Source/FactoryGame/Private/FGBuildableBeam.cpp
+++ b/Source/FactoryGame/Private/FGBuildableBeam.cpp
@@ -9,7 +9,7 @@ AFGBuildableBeam::AFGBuildableBeam(const FObjectInitializer& ObjectInitializer) 
 	this->mMaxLength = 0.0;
 	this->mLength = 0.0;
 }
-void AFGBuildableBeam::BeginPlay(){ }
+void AFGBuildableBeam::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableBeam::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableBeam, mLength);

--- a/Source/FactoryGame/Private/FGBuildableDoor.cpp
+++ b/Source/FactoryGame/Private/FGBuildableDoor.cpp
@@ -14,8 +14,8 @@ AFGBuildableDoor::AFGBuildableDoor() : Super() {
 	this->Steps = 2;
 	this->mManagedByLightweightBuildableSubsystem = false;
 }
-void AFGBuildableDoor::BeginPlay(){ }
-void AFGBuildableDoor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGBuildableDoor::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableDoor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGBuildableDoor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableDoor, mDoorState);

--- a/Source/FactoryGame/Private/FGBuildablePipePart.cpp
+++ b/Source/FactoryGame/Private/FGBuildablePipePart.cpp
@@ -24,7 +24,7 @@ void AFGBuildablePipePart::GetLifetimeReplicatedProps(TArray< FLifetimeProperty 
 	DOREPLIFETIME(AFGBuildablePipePart, mLength);
 	DOREPLIFETIME(AFGBuildablePipePart, mSupportMesh);
 }
-void AFGBuildablePipePart::BeginPlay(){ }
+void AFGBuildablePipePart::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildablePipePart::SetSupportLength(float length){ }
 void AFGBuildablePipePart::SetupConnectionComponent(){ }
 const FName AFGBuildablePipePart::SupportMeshName = FName();

--- a/Source/FactoryGame/Private/FGBuildablePipelineFlowIndicator.cpp
+++ b/Source/FactoryGame/Private/FGBuildablePipelineFlowIndicator.cpp
@@ -22,9 +22,9 @@ void AFGBuildablePipelineFlowIndicator::GetLifetimeReplicatedProps(TArray< FLife
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildablePipelineFlowIndicator, mOwningPipeline);
 }
-void AFGBuildablePipelineFlowIndicator::BeginPlay(){ }
-void AFGBuildablePipelineFlowIndicator::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGBuildablePipelineFlowIndicator::Tick(float dt){ }
+void AFGBuildablePipelineFlowIndicator::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildablePipelineFlowIndicator::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildablePipelineFlowIndicator::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildablePipelineFlowIndicator::GainedSignificance_Implementation(){ }
 void AFGBuildablePipelineFlowIndicator::LostSignificance_Implementation(){ }
 void AFGBuildablePipelineFlowIndicator::GainedSignificance_Native(){ }

--- a/Source/FactoryGame/Private/FGBuildablePipelineSupport.cpp
+++ b/Source/FactoryGame/Private/FGBuildablePipelineSupport.cpp
@@ -27,7 +27,7 @@ void AFGBuildablePipelineSupport::GetLifetimeReplicatedProps(TArray< FLifetimePr
 	DOREPLIFETIME(AFGBuildablePipelineSupport, mVerticalAngle);
 	DOREPLIFETIME(AFGBuildablePipelineSupport, mSupportMesh);
 }
-void AFGBuildablePipelineSupport::BeginPlay(){ }
+void AFGBuildablePipelineSupport::BeginPlay(){ Super::BeginPlay(); }
 TArray<struct FInstanceData> AFGBuildablePipelineSupport::GetActorLightweightInstanceData_Implementation(){ return TArray<struct FInstanceData>(); }
 void AFGBuildablePipelineSupport::SetSupportLength(float length){ }
 void AFGBuildablePipelineSupport::SetVerticalAngle(float angle){ }

--- a/Source/FactoryGame/Private/FGBuildablePowerBooster.cpp
+++ b/Source/FactoryGame/Private/FGBuildablePowerBooster.cpp
@@ -20,7 +20,7 @@ void AFGBuildablePowerBooster::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGBuildablePowerBooster, mHasFuelCached);
 }
 void AFGBuildablePowerBooster::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
-void AFGBuildablePowerBooster::BeginPlay(){ }
+void AFGBuildablePowerBooster::BeginPlay(){ Super::BeginPlay(); }
 bool AFGBuildablePowerBooster::CanProduce_Implementation() const{ return bool(); }
 float AFGBuildablePowerBooster::GetProductionProgress() const{ return float(); }
 float AFGBuildablePowerBooster::GetProductionCycleTime() const{ return float(); }

--- a/Source/FactoryGame/Private/FGBuildableSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGBuildableSubsystem.cpp
@@ -83,9 +83,9 @@ void AFGBuildableSubsystem::PostLoadGame_Implementation(int32 saveVersion, int32
 void AFGBuildableSubsystem::GatherDependencies_Implementation(TArray< UObject* >& out_dependentObjects){ }
 bool AFGBuildableSubsystem::NeedTransform_Implementation(){ return bool(); }
 bool AFGBuildableSubsystem::ShouldSave_Implementation() const{ return bool(); }
-void AFGBuildableSubsystem::BeginPlay(){ }
-void AFGBuildableSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGBuildableSubsystem::Tick(float dt){ }
+void AFGBuildableSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGBuildableSubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGBuildableSubsystem::TickFactory(float dt, ELevelTick TickType){ }
 AFGBuildableSubsystem* AFGBuildableSubsystem::Get(UWorld* world){ return nullptr; }
 AFGBuildableSubsystem* AFGBuildableSubsystem::Get(UObject* worldContext){ return nullptr; }

--- a/Source/FactoryGame/Private/FGCentralStorageSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGCentralStorageSubsystem.cpp
@@ -15,7 +15,7 @@ void AFGCentralStorageSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProp
 	DOREPLIFETIME(AFGCentralStorageSubsystem, mStoredItems);
 	DOREPLIFETIME(AFGCentralStorageSubsystem, mItemStackLimit);
 }
-void AFGCentralStorageSubsystem::BeginPlay(){ }
+void AFGCentralStorageSubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGCentralStorageSubsystem::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 void AFGCentralStorageSubsystem::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 int32 AFGCentralStorageSubsystem::GetNumItemsFromCentralStorage(TSubclassOf<  UFGItemDescriptor > itemClass){ return int32(); }

--- a/Source/FactoryGame/Private/FGCharacterBase.cpp
+++ b/Source/FactoryGame/Private/FGCharacterBase.cpp
@@ -57,9 +57,9 @@ void AFGCharacterBase::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 	DOREPLIFETIME(AFGCharacterBase, mRagdollMeshAngularVelocity);
 	DOREPLIFETIME(AFGCharacterBase, mIsPossessed);
 }
-void AFGCharacterBase::BeginPlay(){ }
-void AFGCharacterBase::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGCharacterBase::Tick(float deltaTime){ }
+void AFGCharacterBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGCharacterBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGCharacterBase::Tick(float deltaTime){ Super::Tick(deltaTime); }
 void AFGCharacterBase::CalcCamera(float DeltaTime, FMinimalViewInfo& OutResult){ }
 float AFGCharacterBase::TakeDamage(float DamageAmount,  FDamageEvent const& DamageEvent,  AController* EventInstigator, AActor* DamageCauser){ return float(); }
 void AFGCharacterBase::ApplyDamageMomentum(float DamageTaken, FDamageEvent const& DamageEvent, APawn* PawnInstigator, AActor* DamageCauser){ }

--- a/Source/FactoryGame/Private/FGCharacterPlayer.cpp
+++ b/Source/FactoryGame/Private/FGCharacterPlayer.cpp
@@ -197,11 +197,11 @@ void AFGCharacterPlayer::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >&
 }
 void AFGCharacterPlayer::PostActorCreated(){ Super::PostActorCreated(); }
 void AFGCharacterPlayer::PostInitializeComponents(){ Super::PostInitializeComponents(); }
-void AFGCharacterPlayer::BeginPlay(){ }
-void AFGCharacterPlayer::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGCharacterPlayer::Tick(float deltaTime){ }
+void AFGCharacterPlayer::BeginPlay(){ Super::BeginPlay(); }
+void AFGCharacterPlayer::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGCharacterPlayer::Tick(float deltaTime){ Super::Tick(deltaTime); }
 bool AFGCharacterPlayer::CanBeBaseForCharacter(APawn* Pawn) const{ return bool(); }
-void AFGCharacterPlayer::Destroyed(){ }
+void AFGCharacterPlayer::Destroyed(){ Super::Destroyed(); }
 bool AFGCharacterPlayer::IsLocallyControlled() const{ return bool(); }
 void AFGCharacterPlayer::PossessedBy(AController* newController){ }
 void AFGCharacterPlayer::UnPossessed(){ }

--- a/Source/FactoryGame/Private/FGCircuitSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGCircuitSubsystem.cpp
@@ -34,8 +34,8 @@ bool AFGCircuitSubsystem::NeedTransform_Implementation(){ return bool(); }
 bool AFGCircuitSubsystem::ShouldSave_Implementation() const{ return bool(); }
 void AFGCircuitSubsystem::Serialize(FArchive& ar){ Super::Serialize(ar); }
 void AFGCircuitSubsystem::AddReferencedObjects(UObject* InThis, FReferenceCollector& Collector){ }
-void AFGCircuitSubsystem::BeginPlay(){ }
-void AFGCircuitSubsystem::Tick(float DeltaSeconds){ }
+void AFGCircuitSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGCircuitSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGCircuitSubsystem::DebugRebuildAll(){ }
 void AFGCircuitSubsystem::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 void AFGCircuitSubsystem::ConnectComponents( UFGCircuitConnectionComponent* first,  UFGCircuitConnectionComponent* second){ }

--- a/Source/FactoryGame/Private/FGCliffActor.cpp
+++ b/Source/FactoryGame/Private/FGCliffActor.cpp
@@ -13,8 +13,8 @@ AFGCliffActorManager::AFGCliffActorManager() : Super() {
 	this->PrimaryActorTick.TickInterval = 1.0;
 }
 void AFGCliffActorManager::EnqueueTask(UWorld* World, FAsyncTask<class FFGAsyncCliffGrassBuilderTask>* inAsyncTask, AFGCliffActor* inActor){ }
-void AFGCliffActorManager::Tick(float DeltaSeconds){ }
-void AFGCliffActorManager::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGCliffActorManager::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGCliffActorManager::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 #if WITH_EDITOR
 void AFGCliffActor::ConvertStaticMeshActorToOnTopMesh(AActor* SelectedActor, FString& ResultMsg){ }
 void AFGCliffActor::UpdateAssociatedCliffActorsAndReParent(){ }
@@ -30,8 +30,8 @@ AFGCliffActor::AFGCliffActor() : Super() {
 	this->mSignificanceRangeMultiplier = 1.25;
 	this->RootComponent = mMeshComponent;
 }
-void AFGCliffActor::BeginPlay(){ }
-void AFGCliffActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGCliffActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGCliffActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGCliffActor::OnConstruction(const FTransform& Transform){ }
 void AFGCliffActor::GainedSignificance_Implementation(){ }
 void AFGCliffActor::LostSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/FGColoredInstanceMeshProxy.cpp
+++ b/Source/FactoryGame/Private/FGColoredInstanceMeshProxy.cpp
@@ -28,7 +28,7 @@ UFGColoredInstanceMeshProxy::UFGColoredInstanceMeshProxy() : Super() {
 	this->PrimaryComponentTick.bAllowTickOnDedicatedServer = false;
 	this->PrimaryComponentTick.TickInterval = 0.0;
 }
-void UFGColoredInstanceMeshProxy::BeginPlay(){ }
+void UFGColoredInstanceMeshProxy::BeginPlay(){ Super::BeginPlay(); }
 void UFGColoredInstanceMeshProxy::OnRegister(){ Super::OnRegister(); }
 void UFGColoredInstanceMeshProxy::OnUnregister(){ Super::OnUnregister(); }
 void UFGColoredInstanceMeshProxy::SetCustomizationData(const FFactoryCustomizationData& customizationData){ }

--- a/Source/FactoryGame/Private/FGColoredVTXAnimMesh.cpp
+++ b/Source/FactoryGame/Private/FGColoredVTXAnimMesh.cpp
@@ -35,8 +35,8 @@ UFGColoredVTXAnimMesh::UFGColoredVTXAnimMesh() : Super() {
 	this->mProductionStateID = 22;
 }
 void UFGColoredVTXAnimMesh::UpdateEffectTimeline(const float Dt, const float Dist, const float WorldTime){ }
-void UFGColoredVTXAnimMesh::BeginPlay(){ }
-void UFGColoredVTXAnimMesh::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGColoredVTXAnimMesh::BeginPlay(){ Super::BeginPlay(); }
+void UFGColoredVTXAnimMesh::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGColoredVTXAnimMesh::GainedSignificance_Implementation(){ }
 void UFGColoredVTXAnimMesh::LostSignificance_Implementation(){ }
 void UFGColoredVTXAnimMesh::StopAnimation(float WorldTime){ }

--- a/Source/FactoryGame/Private/FGColoredVTXAnimMeshInterface.cpp
+++ b/Source/FactoryGame/Private/FGColoredVTXAnimMeshInterface.cpp
@@ -13,7 +13,7 @@ UFGColoredVTXAnimMeshInterface::UFGColoredVTXAnimMeshInterface() : Super() {
 	this->mDefaultStopAnimDuration = 0.0;
 	this->mBlockInstancing = true;
 }
-void UFGColoredVTXAnimMeshInterface::BeginPlay(){ }
+void UFGColoredVTXAnimMeshInterface::BeginPlay(){ Super::BeginPlay(); }
 void UFGColoredVTXAnimMeshInterface::SetupDelegates(bool bShouldDoInitialCall){ }
 void UFGColoredVTXAnimMeshInterface::SetupDefaultPrimitiveValues(){ }
 bool UFGColoredVTXAnimMeshInterface::ShouldPlayStartAnimation(EProductionStatus NewState, EProductionStatus OldState){ return bool(); }

--- a/Source/FactoryGame/Private/FGConveyorChainActor.cpp
+++ b/Source/FactoryGame/Private/FGConveyorChainActor.cpp
@@ -25,8 +25,8 @@ AFGConveyorChainActor::AFGConveyorChainActor() : Super() {
 	this->bReplicates = true;
 	this->RootComponent = mSceneComponent;
 }
-void AFGConveyorChainActor::BeginPlay(){ }
-void AFGConveyorChainActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGConveyorChainActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGConveyorChainActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGConveyorChainActor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGConveyorChainActor, mTotalLength);
@@ -34,7 +34,7 @@ void AFGConveyorChainActor::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>
 	DOREPLIFETIME(AFGConveyorChainActor, mItemAdditions);
 	DOREPLIFETIME(AFGConveyorChainActor, mSpeedOfSlowestBelt);
 }
-void AFGConveyorChainActor::Tick(float DeltaSeconds){ }
+void AFGConveyorChainActor::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGConveyorChainActor::Serialize(FArchive& ar){ Super::Serialize(ar); }
 void AFGConveyorChainActor::BuildLUT(){ }
 void AFGConveyorChainActor::NotifyActorChannelClosedForNetConnection(UNetConnection* NetConnection){ }

--- a/Source/FactoryGame/Private/FGConveyorChainSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGConveyorChainSubsystem.cpp
@@ -34,8 +34,8 @@ void AFGConveyorChainSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimePrope
 	DOREPLIFETIME(AFGConveyorChainSubsystem, mServerFactoryTickTime);
 	DOREPLIFETIME(AFGConveyorChainSubsystem, mAllItemDescriptors);
 }
-void AFGConveyorChainSubsystem::BeginPlay(){ }
-void AFGConveyorChainSubsystem::Tick(float DeltaSeconds){ }
+void AFGConveyorChainSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGConveyorChainSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGConveyorChainSubsystem::OnConveyorItemMovementQualityUpdated(FString cvar){ }
 void AFGConveyorChainSubsystem::AddConveyorChain(AFGConveyorChainActor* chainActor){ }
 void AFGConveyorChainSubsystem::RemoveConveyorChain(AFGConveyorChainActor* chainActor){ }

--- a/Source/FactoryGame/Private/FGConveyorInstanceSplineMesh.cpp
+++ b/Source/FactoryGame/Private/FGConveyorInstanceSplineMesh.cpp
@@ -2,9 +2,9 @@
 
 #include "FGConveyorInstanceSplineMesh.h"
 
-void UFGConveyorInstancedSplineMeshComponent::BeginPlay(){ }
+void UFGConveyorInstancedSplineMeshComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGConveyorInstancedSplineMeshComponent::ReportVisibility() const{ }
-void UFGConveyorLiftVisibilityMesh::BeginPlay(){ }
+void UFGConveyorLiftVisibilityMesh::BeginPlay(){ Super::BeginPlay(); }
 void UFGConveyorLiftVisibilityMesh::ReportVisibility() const{ }
-void UFGConveyorBeltVisibilityMesh::BeginPlay(){ }
+void UFGConveyorBeltVisibilityMesh::BeginPlay(){ Super::BeginPlay(); }
 void UFGConveyorBeltVisibilityMesh::ReportVisibility() const{ }

--- a/Source/FactoryGame/Private/FGConveyorItemSubSystem.cpp
+++ b/Source/FactoryGame/Private/FGConveyorItemSubSystem.cpp
@@ -24,9 +24,9 @@ AFGConveyorItemSubsystem* AFGConveyorItemSubsystem::Get(UWorld* world){ return n
 void AFGConveyorItemSubsystem::LazyAddConveyorItemOfClass(UClass* Descriptor){ }
 void AFGConveyorItemSubsystem::AddLookupTable(AFGConveyorChainActor* Actor, const TArray<FVector3f>& Position, const TArray<FQuat4f>& Quats){ }
 void AFGConveyorItemSubsystem::RemoveChainActorFromLookupTable(AFGConveyorChainActor* ChainActor){ }
-void AFGConveyorItemSubsystem::Tick(float DeltaSeconds){ }
-void AFGConveyorItemSubsystem::BeginPlay(){ }
-void AFGConveyorItemSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGConveyorItemSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGConveyorItemSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGConveyorItemSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGConveyorItemSubsystem::InitializeConveyorItems(){ }
 void AFGConveyorItemSubsystem::Update(){ }
 void AFGConveyorItemSubsystem::CleanupLookupTables(){ }

--- a/Source/FactoryGame/Private/FGCrashSiteDebris.cpp
+++ b/Source/FactoryGame/Private/FGCrashSiteDebris.cpp
@@ -8,7 +8,7 @@
 void AFGCrashSiteDebris::PreSave(FObjectPreSaveContext SaveContext){ }
 void AFGCrashSiteDebris::PreEditChange(FProperty* PropertyAboutToChange){ }
 void AFGCrashSiteDebris::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent){ Super::PostEditChangeProperty(PropertyChangedEvent); }
-void AFGCrashSiteDebris::Tick(float dt){ }
+void AFGCrashSiteDebris::Tick(float dt){ Super::Tick(dt); }
 bool AFGCrashSiteDebris::ShouldTickIfViewportsOnly() const{ return bool(); }
 void AFGCrashSiteDebris::ResetSavedSimulation(){ }
 void AFGCrashSiteDebris::SpawnSimulation(){ }

--- a/Source/FactoryGame/Private/FGCrashSiteDebrisActor.cpp
+++ b/Source/FactoryGame/Private/FGCrashSiteDebrisActor.cpp
@@ -8,8 +8,8 @@ AFGCrashSiteDebrisActor::AFGCrashSiteDebrisActor() : Super() {
 	this->mMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Mesh"));
 	this->RootComponent = mMesh;
 }
-void AFGCrashSiteDebrisActor::BeginPlay(){ }
-void AFGCrashSiteDebrisActor::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGCrashSiteDebrisActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGCrashSiteDebrisActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGCrashSiteDebrisActor::GainedSignificance_Implementation(){ }
 void AFGCrashSiteDebrisActor::LostSignificance_Implementation(){ }
 void AFGCrashSiteDebrisActor::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGCrate.cpp
+++ b/Source/FactoryGame/Private/FGCrate.cpp
@@ -20,8 +20,8 @@ void AFGCrate::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetime
 	DOREPLIFETIME(AFGCrate, mInventory);
 }
 void AFGCrate::PostActorCreated(){ Super::PostActorCreated(); }
-void AFGCrate::BeginPlay(){ }
-void AFGCrate::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGCrate::BeginPlay(){ Super::BeginPlay(); }
+void AFGCrate::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGCrate::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 bool AFGCrate::AddAsRepresentation(){ return bool(); }
 bool AFGCrate::UpdateRepresentation(){ return bool(); }

--- a/Source/FactoryGame/Private/FGCreatureSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGCreatureSubsystem.cpp
@@ -15,8 +15,8 @@ AFGCreatureSubsystem::AFGCreatureSubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGCreatureSubsystem::BeginPlay(){ }
-void AFGCreatureSubsystem::Tick(float dt){ }
+void AFGCreatureSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGCreatureSubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGCreatureSubsystem::RegisterSpawner( AFGCreatureSpawner* spawner){ }
 void AFGCreatureSubsystem::UnregisterSpawner( AFGCreatureSpawner* spawner){ }
 void AFGCreatureSubsystem::RegisterCreature( AFGCreature* creature){ }

--- a/Source/FactoryGame/Private/FGDestructibleActor.cpp
+++ b/Source/FactoryGame/Private/FGDestructibleActor.cpp
@@ -24,7 +24,7 @@ AFGDestructibleActor::AFGDestructibleActor() : Super() {
 	this->NetDormancy = ENetDormancy::DORM_DormantAll;
 	this->RootComponent = mStaticMeshProxy;
 }
-void AFGDestructibleActor::BeginPlay(){ }
+void AFGDestructibleActor::BeginPlay(){ Super::BeginPlay(); }
 float AFGDestructibleActor::TakeDamage(float damage,  FDamageEvent const& damageEvent, AController* eventInstigator, AActor* damageCauser){ return float(); }
 void AFGDestructibleActor::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGDestructibleActor::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGDotReceiverComponent.cpp
+++ b/Source/FactoryGame/Private/FGDotReceiverComponent.cpp
@@ -11,7 +11,7 @@ UFGDotReceiverComponent::UFGDotReceiverComponent() : Super() {
 	this->PrimaryComponentTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryComponentTick.TickInterval = 0.0;
 }
-void UFGDotReceiverComponent::BeginPlay(){ }
+void UFGDotReceiverComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGDotReceiverComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction){ }
 void UFGDotReceiverComponent::RegisterActiveDOT(TSubclassOf<  UFGDamageOverTime > DotClass, AActor* SourceActor){ }
 void UFGDotReceiverComponent::UnregisterActiveDOT(TSubclassOf<  UFGDamageOverTime > DotClass, AActor* SourceActor){ }

--- a/Source/FactoryGame/Private/FGDroneMovementComponent.cpp
+++ b/Source/FactoryGame/Private/FGDroneMovementComponent.cpp
@@ -19,8 +19,8 @@ UFGDroneMovementComponent::UFGDroneMovementComponent() : Super() {
 	this->SetIsReplicatedByDefault(true);
 }
 void UFGDroneMovementComponent::OnRegister(){ Super::OnRegister(); }
-void UFGDroneMovementComponent::BeginPlay(){ }
-void UFGDroneMovementComponent::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGDroneMovementComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGDroneMovementComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGDroneMovementComponent::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(UFGDroneMovementComponent, mFlyingMode);

--- a/Source/FactoryGame/Private/FGDroneStationInfo.cpp
+++ b/Source/FactoryGame/Private/FGDroneStationInfo.cpp
@@ -48,7 +48,7 @@ void AFGDroneStationInfo::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >
 	DOREPLIFETIME(AFGDroneStationInfo, mLastInsertedFuelType);
 	DOREPLIFETIME(AFGDroneStationInfo, mDroneTripStatistics);
 }
-void AFGDroneStationInfo::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGDroneStationInfo::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 void AFGDroneStationInfo::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGDroneStationInfo::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGDroneStationInfo::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGDroneSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGDroneSubsystem.cpp
@@ -14,13 +14,13 @@ AFGDroneSubsystem::AFGDroneSubsystem() : Super() {
 }
 AFGDroneSubsystem* AFGDroneSubsystem::Get(UWorld* world){ return nullptr; }
 AFGDroneSubsystem* AFGDroneSubsystem::Get(UObject* worldContext){ return nullptr; }
-void AFGDroneSubsystem::BeginPlay(){ }
+void AFGDroneSubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGDroneSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGDroneSubsystem, mStations);
 	DOREPLIFETIME(AFGDroneSubsystem, mDrones);
 }
-void AFGDroneSubsystem::Tick(float DeltaSeconds){ }
+void AFGDroneSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGDroneSubsystem::AddStation( AFGBuildableDroneStation* station){ }
 void AFGDroneSubsystem::RemoveStation( AFGBuildableDroneStation* station){ }
 void AFGDroneSubsystem::RegisterDrone( AFGDroneVehicle* drone){ }

--- a/Source/FactoryGame/Private/FGDroneVehicle.cpp
+++ b/Source/FactoryGame/Private/FGDroneVehicle.cpp
@@ -38,8 +38,8 @@ AFGDroneVehicle::AFGDroneVehicle() : Super() {
 	this->mCurrentAction = nullptr;
 }
 void AFGDroneVehicle::Serialize(FArchive& Ar){ Super::Serialize(Ar); }
-void AFGDroneVehicle::BeginPlay(){ }
-void AFGDroneVehicle::Tick(float DeltaTime){ }
+void AFGDroneVehicle::BeginPlay(){ Super::BeginPlay(); }
+void AFGDroneVehicle::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGDroneVehicle::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGDroneVehicle, mMovementComponent);
@@ -47,7 +47,7 @@ void AFGDroneVehicle::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutL
 	DOREPLIFETIME(AFGDroneVehicle, mCurrentDockingState);
 	DOREPLIFETIME(AFGDroneVehicle, mDockedStation);
 }
-void AFGDroneVehicle::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGDroneVehicle::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGDroneVehicle::PostNetReceiveLocationAndRotation(){ }
 bool AFGDroneVehicle::IsUseable_Implementation() const{ return bool(); }
 void AFGDroneVehicle::Dismantle_Implementation(){ }

--- a/Source/FactoryGame/Private/FGDropPod.cpp
+++ b/Source/FactoryGame/Private/FGDropPod.cpp
@@ -46,8 +46,8 @@ void AFGDropPod::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifeti
 	DOREPLIFETIME(AFGDropPod, mPropertyReplicator);
 	DOREPLIFETIME(AFGDropPod, mHasBeenOpened);
 }
-void AFGDropPod::BeginPlay(){ }
-void AFGDropPod::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGDropPod::BeginPlay(){ Super::BeginPlay(); }
+void AFGDropPod::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 void AFGDropPod::PreSave(FObjectPreSaveContext SaveContext){ Super::PreSave(SaveContext); }
 void AFGDropPod::GainedSignificance_Implementation(){ }
 void AFGDropPod::LostSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/FGEquipmentChild.cpp
+++ b/Source/FactoryGame/Private/FGEquipmentChild.cpp
@@ -16,7 +16,7 @@ AFGEquipmentChild::AFGEquipmentChild() : Super() {
 	this->bNetUseOwnerRelevancy = true;
 	this->bReplicates = true;
 }
-void AFGEquipmentChild::BeginPlay(){ }
+void AFGEquipmentChild::BeginPlay(){ Super::BeginPlay(); }
 void AFGEquipmentChild::Equip( AFGCharacterPlayer* character,  AFGEquipment* parentEquipment){ }
 void AFGEquipmentChild::UnEquip(){ }
 void AFGEquipmentChild::OnEquip_Implementation( AFGCharacterPlayer* character){ }

--- a/Source/FactoryGame/Private/FGFluffActor.cpp
+++ b/Source/FactoryGame/Private/FGFluffActor.cpp
@@ -5,6 +5,6 @@
 AFGFluffActor::AFGFluffActor() : Super() {
 
 }
-void AFGFluffActor::BeginPlay(){ }
-void AFGFluffActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGFluffActor::Tick(float DeltaTime){ }
+void AFGFluffActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGFluffActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGFluffActor::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/FGFoliagePickup.cpp
+++ b/Source/FactoryGame/Private/FGFoliagePickup.cpp
@@ -18,8 +18,8 @@ AFGFoliagePickup::AFGFoliagePickup() : Super() {
 	this->bNetUseOwnerRelevancy = true;
 	this->bReplicates = true;
 }
-void AFGFoliagePickup::BeginPlay(){ }
-void AFGFoliagePickup::Tick(float DeltaSeconds){ }
+void AFGFoliagePickup::BeginPlay(){ Super::BeginPlay(); }
+void AFGFoliagePickup::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGFoliagePickup::UpdateUseState_Implementation( AFGCharacterPlayer* byCharacter, const FVector& atLocation,  UPrimitiveComponent* componentHit, FUseState& out_useState){ }
 bool AFGFoliagePickup::IsUseable_Implementation() const{ return bool(); }
 void AFGFoliagePickup::StartIsLookedAt_Implementation( AFGCharacterPlayer* byCharacter, const FUseState& state){ }

--- a/Source/FactoryGame/Private/FGFoliageRemovalSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGFoliageRemovalSubsystem.cpp
@@ -17,9 +17,9 @@ void AFGFoliageRemovalSubsystem::PostLoad(){ Super::PostLoad(); }
 AFGFoliageRemovalSubsystem::AFGFoliageRemovalSubsystem() : Super() {
 
 }
-void AFGFoliageRemovalSubsystem::BeginPlay(){ }
-void AFGFoliageRemovalSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGFoliageRemovalSubsystem::Destroyed(){ }
+void AFGFoliageRemovalSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGFoliageRemovalSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGFoliageRemovalSubsystem::Destroyed(){ Super::Destroyed(); }
 void AFGFoliageRemovalSubsystem::Serialize(FArchive& Ar){ Super::Serialize(Ar); }
 void AFGFoliageRemovalSubsystem::AddReferencedObjects(UObject* InThis, FReferenceCollector& Collector){ }
 void AFGFoliageRemovalSubsystem::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGFoliageStateRepProxy.cpp
+++ b/Source/FactoryGame/Private/FGFoliageStateRepProxy.cpp
@@ -37,7 +37,7 @@ void AFGFoliageStateRepProxy::GetLifetimeReplicatedProps(TArray<FLifetimePropert
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGFoliageStateRepProxy, mPendingBundles);
 }
-void AFGFoliageStateRepProxy::Tick(float DeltaTime){ }
-void AFGFoliageStateRepProxy::BeginPlay(){ }
+void AFGFoliageStateRepProxy::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
+void AFGFoliageStateRepProxy::BeginPlay(){ Super::BeginPlay(); }
 void AFGFoliageStateRepProxy::Server_ConfirmFullyReplicated_Implementation(UFGFoliageRemovalBundle* replicator){ }
 void AFGFoliageStateRepProxy::OnFoliageBucketRemoved(const FIntVector& inCell, const UFoliageType* forFoliageType, int32 bucketId){ }

--- a/Source/FactoryGame/Private/FGFreightWagon.cpp
+++ b/Source/FactoryGame/Private/FGFreightWagon.cpp
@@ -23,8 +23,8 @@ void AFGFreightWagon::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutL
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGFreightWagon, mCargoMeshComponentDerailedTransform);
 }
-void AFGFreightWagon::BeginPlay(){ }
-void AFGFreightWagon::Tick(float dt){ }
+void AFGFreightWagon::BeginPlay(){ Super::BeginPlay(); }
+void AFGFreightWagon::Tick(float dt){ Super::Tick(dt); }
 UPawnMovementComponent* AFGFreightWagon::GetMovementComponent() const{ return nullptr; }
 UFGRailroadVehicleMovementComponent* AFGFreightWagon::GetRailroadVehicleMovementComponent() const{ return nullptr; }
 FText AFGFreightWagon::GetLookAtDecription_Implementation(AFGCharacterPlayer* byCharacter, const FUseState& state) const{ return FText(); }

--- a/Source/FactoryGame/Private/FGFrontendStateComponent.cpp
+++ b/Source/FactoryGame/Private/FGFrontendStateComponent.cpp
@@ -6,8 +6,8 @@ UFGFrontendStateComponent::UFGFrontendStateComponent(const FObjectInitializer& O
 	this->mAuthenticationSequence = nullptr;
 	this->mOnlineIntegrationModeModel = nullptr;
 }
-void UFGFrontendStateComponent::BeginPlay(){ }
-void UFGFrontendStateComponent::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGFrontendStateComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGFrontendStateComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGFrontendStateComponent::OnOnlineIntegrationModeChanged(EOnlineIntegrationMode mode){ }
 void UFGFrontendStateComponent::AuthenticationSequenceComplete(UOnlineAsyncOperation* InAsyncOp){ }
 void UFGFrontendStateComponent::OnlineModeSelectionConfirmed(bool popupConfirmed){ }

--- a/Source/FactoryGame/Private/FGGameMode.cpp
+++ b/Source/FactoryGame/Private/FGGameMode.cpp
@@ -39,9 +39,9 @@ AFGGameMode::AFGGameMode() : Super() {
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
 void AFGGameMode::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGGameMode::BeginPlay(){ }
-void AFGGameMode::Tick(float DeltaSeconds){ }
-void AFGGameMode::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGGameMode::BeginPlay(){ Super::BeginPlay(); }
+void AFGGameMode::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGGameMode::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGGameMode::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGameMode::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGameMode::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGGamePhaseManager.cpp
+++ b/Source/FactoryGame/Private/FGGamePhaseManager.cpp
@@ -20,8 +20,8 @@ void AFGGamePhaseManager::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(AFGGamePhaseManager, mIsGameCompleted);
 }
 void AFGGamePhaseManager::PostInitializeComponents(){ Super::PostInitializeComponents(); }
-void AFGGamePhaseManager::BeginPlay(){ }
-void AFGGamePhaseManager::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGGamePhaseManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGGamePhaseManager::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGGamePhaseManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGamePhaseManager::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGamePhaseManager::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGGameRulesSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGGameRulesSubsystem.cpp
@@ -16,7 +16,7 @@ void UFGGameRulesRemoteCallObject::Server_SetNoUnlockCost_Implementation(bool en
 void UFGGameRulesRemoteCallObject::Server_SetNoPower_Implementation(bool enabled){ }
 void UFGGameRulesRemoteCallObject::Server_SetArachnidCreaturesDisabled_Implementation(bool disabled){ }
 void UFGGameRulesRemoteCallObject::Server_SetGamePhase_Implementation(int32 gamePhase){ }
-void AFGGameRulesSubsystem::BeginPlay(){ }
+void AFGGameRulesSubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGGameRulesSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGGameRulesSubsystem, mHasInitialized);

--- a/Source/FactoryGame/Private/FGGameSessionOnline.cpp
+++ b/Source/FactoryGame/Private/FGGameSessionOnline.cpp
@@ -6,7 +6,7 @@ AFGGameSessionOnline::AFGGameSessionOnline() : Super() {
 	this->mSessionInformation = nullptr;
 }
 void AFGGameSessionOnline::UpdateGameSession(){ }
-void AFGGameSessionOnline::Destroyed(){ }
+void AFGGameSessionOnline::Destroyed(){ Super::Destroyed(); }
 void AFGGameSessionOnline::InitOptions(const FString& options){ }
 void AFGGameSessionOnline::HandleMatchHasStarted(){ }
 void AFGGameSessionOnline::HandleMatchHasEnded(){ }

--- a/Source/FactoryGame/Private/FGGameState.cpp
+++ b/Source/FactoryGame/Private/FGGameState.cpp
@@ -107,7 +107,7 @@ void AFGGameState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLife
 	DOREPLIFETIME(AFGGameState, mPublicTodoList);
 	DOREPLIFETIME(AFGGameState, mIsCreativeModeEnabled);
 }
-void AFGGameState::BeginPlay(){ }
+void AFGGameState::BeginPlay(){ Super::BeginPlay(); }
 void AFGGameState::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGameState::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGGameState::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGGasPillar.cpp
+++ b/Source/FactoryGame/Private/FGGasPillar.cpp
@@ -23,8 +23,8 @@ AFGGasPillar::AFGGasPillar() : Super() {
 	this->mBindChaosPhysicsCollisionEvent = true;
 	this->RootComponent = mMesh;
 }
-void AFGGasPillar::BeginPlay(){ }
-void AFGGasPillar::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGGasPillar::BeginPlay(){ Super::BeginPlay(); }
+void AFGGasPillar::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGGasPillar::PostUnregisterAllComponents(void){ }
 void AFGGasPillar::PostRegisterAllComponents(){ }
 void AFGGasPillar::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {

--- a/Source/FactoryGame/Private/FGGasPillarCloud.cpp
+++ b/Source/FactoryGame/Private/FGGasPillarCloud.cpp
@@ -19,8 +19,8 @@ AFGGasPillarCloud::AFGGasPillarCloud() : Super() {
 	this->mIsSignificant = false;
 	this->mHasPendingRefreshOfSystems = false;
 }
-void AFGGasPillarCloud::BeginPlay(){ }
-void AFGGasPillarCloud::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGGasPillarCloud::BeginPlay(){ Super::BeginPlay(); }
+void AFGGasPillarCloud::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGGasPillarCloud::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGGasPillarCloud, mRemovedWorldLocations);

--- a/Source/FactoryGame/Private/FGHUD.cpp
+++ b/Source/FactoryGame/Private/FGHUD.cpp
@@ -18,9 +18,9 @@ AFGHUD::AFGHUD() : Super() {
 	this->mGeneralCrosshair = mDefaultCrosshair;
 }
 void AFGHUD::PostInitializeComponents(){ Super::PostInitializeComponents(); }
-void AFGHUD::BeginPlay(){ }
-void AFGHUD::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGHUD::Tick(float DeltaSeconds){ }
+void AFGHUD::BeginPlay(){ Super::BeginPlay(); }
+void AFGHUD::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGHUD::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGHUD::AddPawnHUD(TSubclassOf<class UUserWidget> widgetClass, APawn* pawn){ }
 void AFGHUD::ShowRespawnUI(){ }
 void AFGHUD::CloseRespawnUI(){ }

--- a/Source/FactoryGame/Private/FGHealthComponent.cpp
+++ b/Source/FactoryGame/Private/FGHealthComponent.cpp
@@ -6,7 +6,7 @@
 #if WITH_EDITOR
 void UFGHealthComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent){ Super::PostEditChangeProperty(PropertyChangedEvent); }
 #endif 
-void UFGHealthComponent::BeginPlay(){ }
+void UFGHealthComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGHealthComponent::PostLoad(){ Super::PostLoad(); }
 void UFGHealthComponent::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void UFGHealthComponent::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGIconDatabaseSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGIconDatabaseSubsystem.cpp
@@ -6,7 +6,7 @@
 AFGIconDatabaseSubsystem::AFGIconDatabaseSubsystem() : Super() {
 	this->mDefaultIconLibrary = nullptr;
 }
-void AFGIconDatabaseSubsystem::BeginPlay(){ }
+void AFGIconDatabaseSubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGIconDatabaseSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGIconDatabaseSubsystem, mGlobalIconLibraries);

--- a/Source/FactoryGame/Private/FGInteractableMarker.cpp
+++ b/Source/FactoryGame/Private/FGInteractableMarker.cpp
@@ -22,6 +22,6 @@ AFGInteractableMarker::AFGInteractableMarker() : Super() {
 	this->mIconWidget->SetupAttachment(RootComponent);
 	this->mSplineMesh->SetupAttachment(RootComponent);
 }
-void AFGInteractableMarker::Tick(float dt){ }
+void AFGInteractableMarker::Tick(float dt){ Super::Tick(dt); }
 void AFGInteractableMarker::SetTrackedActor( AActor* trackedActor){ }
-void AFGInteractableMarker::BeginPlay(){ }
+void AFGInteractableMarker::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGInventoryComponent.cpp
+++ b/Source/FactoryGame/Private/FGInventoryComponent.cpp
@@ -49,7 +49,7 @@ bool UFGInventoryComponent::NeedTransform_Implementation(){ return bool(); }
 bool UFGInventoryComponent::ShouldSave_Implementation() const{ return bool(); }
 void UFGInventoryComponent::GetConditionalReplicatedProps(TArray<FFGCondReplicatedProperty>& outProps) const{ }
 bool UFGInventoryComponent::IsPropertyRelevantForConnection(UNetConnection* netConnection, const FProperty* property) const{ return bool(); }
-void UFGInventoryComponent::BeginPlay(){ }
+void UFGInventoryComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGInventoryComponent::SetDefaultSize(int32 defaultSize){ }
 void UFGInventoryComponent::Resize(int32 newSize){ }
 void UFGInventoryComponent::SortInventory(){ }

--- a/Source/FactoryGame/Private/FGItemPickup.cpp
+++ b/Source/FactoryGame/Private/FGItemPickup.cpp
@@ -28,8 +28,8 @@ void AFGItemPickup::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 	DOREPLIFETIME(AFGItemPickup, mItemState);
 }
 void AFGItemPickup::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGItemPickup::BeginPlay(){ }
-void AFGItemPickup::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGItemPickup::BeginPlay(){ Super::BeginPlay(); }
+void AFGItemPickup::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 void AFGItemPickup::PreSave(FObjectPreSaveContext SaveContext){ Super::PreSave(SaveContext); }
 void AFGItemPickup::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGItemPickup::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGItemPickupMarker.cpp
+++ b/Source/FactoryGame/Private/FGItemPickupMarker.cpp
@@ -11,8 +11,8 @@ void AFGItemPickupMarker::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGItemPickupMarker, mItemDescriptor);
 }
-void AFGItemPickupMarker::BeginPlay(){ }
-void AFGItemPickupMarker::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGItemPickupMarker::BeginPlay(){ Super::BeginPlay(); }
+void AFGItemPickupMarker::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGItemPickupMarker::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGItemPickupMarker::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGItemPickupMarker::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGItemPickup_Spawnable.cpp
+++ b/Source/FactoryGame/Private/FGItemPickup_Spawnable.cpp
@@ -12,8 +12,8 @@ AFGItemPickup_Spawnable::AFGItemPickup_Spawnable() : Super() {
 	this->RootComponent = mMeshComponent;
 }
 void AFGItemPickup_Spawnable::PostLoad(){ Super::PostLoad(); }
-void AFGItemPickup_Spawnable::BeginPlay(){ }
-void AFGItemPickup_Spawnable::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGItemPickup_Spawnable::BeginPlay(){ Super::BeginPlay(); }
+void AFGItemPickup_Spawnable::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGItemPickup_Spawnable::ShouldSave_Implementation() const{ return bool(); }
 bool AFGItemPickup_Spawnable::NeedTransform_Implementation(){ return bool(); }
 void AFGItemPickup_Spawnable::UpdateUseState_Implementation( AFGCharacterPlayer* byCharacter, const FVector& atLocation,  UPrimitiveComponent* componentHit, FUseState& out_useState){ }

--- a/Source/FactoryGame/Private/FGItemRegrowSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGItemRegrowSubsystem.cpp
@@ -12,7 +12,7 @@ AFGItemRegrowSubsystem::AFGItemRegrowSubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 1.0;
 }
-void AFGItemRegrowSubsystem::Tick(float DeltaSeconds){ }
+void AFGItemRegrowSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 AFGItemRegrowSubsystem* AFGItemRegrowSubsystem::Get(UWorld* world){ return nullptr; }
 AFGItemRegrowSubsystem* AFGItemRegrowSubsystem::Get(UObject* worldContext){ return nullptr; }
 void AFGItemRegrowSubsystem::AddPickup( AFGItemPickup* inPickup){ }

--- a/Source/FactoryGame/Private/FGLadderComponent.cpp
+++ b/Source/FactoryGame/Private/FGLadderComponent.cpp
@@ -16,8 +16,8 @@ UFGLadderComponent::UFGLadderComponent(const FObjectInitializer& ObjectInitializ
 }
 void UFGLadderComponent::OnRegister(){ Super::OnRegister(); }
 void UFGLadderComponent::OnUnregister(){ Super::OnUnregister(); }
-void UFGLadderComponent::BeginPlay(){ }
-void UFGLadderComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void UFGLadderComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGLadderComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGLadderComponent::TickComponent(float deltaTime, enum ELevelTick tickType, FActorComponentTickFunction* thisTickFunction){ }
 void UFGLadderComponent::Update(){ }
 void UFGLadderComponent::BeginPotentialClimberOverlap(UPrimitiveComponent* overlappedComp, AActor* other, UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool isFromSweep, const FHitResult& sweepResult){ }

--- a/Source/FactoryGame/Private/FGLightweightBuildableSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGLightweightBuildableSubsystem.cpp
@@ -59,9 +59,9 @@ void AFGLightweightBuildableRepProxy::GetLifetimeReplicatedProps(TArray<FLifetim
 	DOREPLIFETIME(AFGLightweightBuildableRepProxy, mPendingRemovalBundles);
 	DOREPLIFETIME(AFGLightweightBuildableRepProxy, mPendingCustomizationBundle);
 }
-void AFGLightweightBuildableRepProxy::BeginPlay(){ }
-void AFGLightweightBuildableRepProxy::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGLightweightBuildableRepProxy::Tick(float DeltaTime){ }
+void AFGLightweightBuildableRepProxy::BeginPlay(){ Super::BeginPlay(); }
+void AFGLightweightBuildableRepProxy::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGLightweightBuildableRepProxy::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGLightweightBuildableRepProxy::AddConstructedRuntimeDataForIndex(TSubclassOf<  AFGBuildable > buildableClass, FRuntimeBuildableInstanceData& runtimeData, int32 index, uint16 constructId, AActor* instigator, int32
 	                                       blueprintBuildIndex){ }
 void AFGLightweightBuildableRepProxy::AddRemovedRuntimeDataForIndex(TSubclassOf<  AFGBuildable > buildableClass, int32 index){ }
@@ -96,8 +96,8 @@ AFGLightweightBuildableSubsystem::AFGLightweightBuildableSubsystem() : Super() {
 AFGLightweightBuildableSubsystem* AFGLightweightBuildableSubsystem::Get(UWorld* world){ return nullptr; }
 AFGLightweightBuildableSubsystem* AFGLightweightBuildableSubsystem::Get(UObject* worldContext){ return nullptr; }
 void AFGLightweightBuildableSubsystem::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGLightweightBuildableSubsystem::Tick(float DeltaSeconds){ }
-void AFGLightweightBuildableSubsystem::BeginPlay(){ }
+void AFGLightweightBuildableSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGLightweightBuildableSubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGLightweightBuildableSubsystem::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGLightweightBuildableSubsystem::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGLightweightBuildableSubsystem::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGLocomotive.cpp
+++ b/Source/FactoryGame/Private/FGLocomotive.cpp
@@ -29,8 +29,8 @@ AFGLocomotive::AFGLocomotive() : Super() {
 	this->mHeadlightModes[2].Intensity = 0.0;;
 	this->mLocomotiveMenuWidgetClass = nullptr;
 }
-void AFGLocomotive::BeginPlay(){ }
-void AFGLocomotive::Tick(float dt){ }
+void AFGLocomotive::BeginPlay(){ Super::BeginPlay(); }
+void AFGLocomotive::Tick(float dt){ Super::Tick(dt); }
 void AFGLocomotive::PossessedBy(AController* newController){ }
 void AFGLocomotive::UnPossessed(){ }
 bool AFGLocomotive::DriverEnter( AFGCharacterPlayer* driver){ return bool(); }

--- a/Source/FactoryGame/Private/FGMainMenuHUD.cpp
+++ b/Source/FactoryGame/Private/FGMainMenuHUD.cpp
@@ -2,5 +2,5 @@
 
 #include "FGMainMenuHUD.h"
 
-void AFGMainMenuHUD::BeginPlay(){ }
+void AFGMainMenuHUD::BeginPlay(){ Super::BeginPlay(); }
 void AFGMainMenuHUD::Native_ShowMainMenu(){ }

--- a/Source/FactoryGame/Private/FGManta.cpp
+++ b/Source/FactoryGame/Private/FGManta.cpp
@@ -33,7 +33,7 @@ void AFGManta::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetime
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGManta, mCurrentTime);
 }
-void AFGManta::BeginPlay(){ }
-void AFGManta::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGManta::BeginPlay(){ Super::BeginPlay(); }
+void AFGManta::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGManta::UpdateManta(){ }
-void AFGManta::Tick(float DeltaTime){ }
+void AFGManta::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/FGMapManager.cpp
+++ b/Source/FactoryGame/Private/FGMapManager.cpp
@@ -19,9 +19,9 @@ AFGMapManager::AFGMapManager() : Super() {
 	this->PrimaryActorTick.TickInterval = 0.1;
 	this->SetHidden(false);
 }
-void AFGMapManager::BeginPlay(){ }
-void AFGMapManager::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGMapManager::Tick(float dt){ }
+void AFGMapManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGMapManager::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGMapManager::Tick(float dt){ Super::Tick(dt); }
 void AFGMapManager::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 void AFGMapManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGMapManager::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGMinimapCaptureActor.cpp
+++ b/Source/FactoryGame/Private/FGMinimapCaptureActor.cpp
@@ -19,4 +19,4 @@ TArray<TArray<FColor>> AFGMinimapCaptureActor::CreateLayeredPixelArray(FFGHeight
 AFGMinimapCaptureActor::AFGMinimapCaptureActor() : Super() {
 	this->mMapAreaTexture = nullptr;
 }
-void AFGMinimapCaptureActor::BeginPlay(){ }
+void AFGMinimapCaptureActor::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGNewsFeedActor.cpp
+++ b/Source/FactoryGame/Private/FGNewsFeedActor.cpp
@@ -19,6 +19,6 @@ AFGNewsFeedActor::AFGNewsFeedActor() : Super() {
 	this->mNewsFeedURLs[3].GameVersion = EGameVersion::GV_ClosedBeta;
 	this->mNewsFeedURLs[3].URL = TEXT("http://ingamenews.satisfactorygame.com/closed_beta.news");
 }
-void AFGNewsFeedActor::BeginPlay(){ }
+void AFGNewsFeedActor::BeginPlay(){ Super::BeginPlay(); }
 FString AFGNewsFeedActor::GetNewsFeedURL(){ return FString(); }
 void AFGNewsFeedActor::OnResponseReceived(FHttpRequestPtr request, FHttpResponsePtr response, bool wasSuccessful){ }

--- a/Source/FactoryGame/Private/FGPassengerSeat.cpp
+++ b/Source/FactoryGame/Private/FGPassengerSeat.cpp
@@ -10,4 +10,4 @@ void AFGPassengerSeat::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 AFGPassengerSeat::AFGPassengerSeat() : Super() {
 	this->mOuterVehicle = nullptr;
 }
-void AFGPassengerSeat::Tick(float dt){ }
+void AFGPassengerSeat::Tick(float dt){ Super::Tick(dt); }

--- a/Source/FactoryGame/Private/FGPhotoModeManager.cpp
+++ b/Source/FactoryGame/Private/FGPhotoModeManager.cpp
@@ -15,8 +15,8 @@ AFGPhotoModeManager::AFGPhotoModeManager() : Super() {
 }
 AFGPhotoModeManager* AFGPhotoModeManager::Get( UWorld* world){ return nullptr; }
 AFGPhotoModeManager* AFGPhotoModeManager::Get( UObject* worldContext){ return nullptr; }
-void AFGPhotoModeManager::BeginPlay(){ }
-void AFGPhotoModeManager::Tick(float DeltaSeconds){ }
+void AFGPhotoModeManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGPhotoModeManager::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGPhotoModeManager::ToggleAdvancedPhotoMode(){ }
 void AFGPhotoModeManager::AddCurrentPlayerLocation(FFrameTime frameTime){ }
 void AFGPhotoModeManager::AddPlayerLocation(FFrameTime frameTime, FVector location){ }

--- a/Source/FactoryGame/Private/FGPhotoModeWidget.cpp
+++ b/Source/FactoryGame/Private/FGPhotoModeWidget.cpp
@@ -5,8 +5,8 @@
 UFGPhotoModeWidget::UFGPhotoModeWidget(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer) {
 	this->bIsFocusable = true;
 }
-void UFGPhotoModeWidget::NativeConstruct(){ }
-void UFGPhotoModeWidget::NativeDestruct(){ }
+void UFGPhotoModeWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGPhotoModeWidget::NativeDestruct(){ Super::NativeDestruct(); }
 void UFGPhotoModeWidget::ListenForInput(FInputChord inputkeyChord, TEnumAsByte<EInputEvent> eventType, bool consume, FOnInputAction callback){ }
 void UFGPhotoModeWidget::StopListeningForAllInputs(){ }
 void UFGPhotoModeWidget::ToggleMouseControl(){ }

--- a/Source/FactoryGame/Private/FGPioneerPotty.cpp
+++ b/Source/FactoryGame/Private/FGPioneerPotty.cpp
@@ -8,4 +8,4 @@ AFGPioneerPotty::AFGPioneerPotty() : Super() {
 	this->mForceNetUpdateOnRegisterPlayer = true;
 	this->mToggleDormancyOnInteraction = true;
 }
-void AFGPioneerPotty::BeginPlay(){ }
+void AFGPioneerPotty::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGPipeBuilder.cpp
+++ b/Source/FactoryGame/Private/FGPipeBuilder.cpp
@@ -21,9 +21,9 @@ AFGPipeBuilder::AFGPipeBuilder() : Super() {
 	this->mTrailDistance = 500.0;
 	this->mPipeSupportLocation->SetupAttachment(mMesh);
 }
-void AFGPipeBuilder::BeginPlay(){ }
-void AFGPipeBuilder::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGPipeBuilder::Tick(float dt){ }
+void AFGPipeBuilder::BeginPlay(){ Super::BeginPlay(); }
+void AFGPipeBuilder::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGPipeBuilder::Tick(float dt){ Super::Tick(dt); }
 void AFGPipeBuilder::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPipeBuilder, mSplineHologram);

--- a/Source/FactoryGame/Private/FGPipeBuilderTrail.cpp
+++ b/Source/FactoryGame/Private/FGPipeBuilderTrail.cpp
@@ -19,5 +19,5 @@ void AFGPipeBuilderTrail::AddPipeline( AFGBuildablePipeline* inPipe){ }
 void AFGPipeBuilderTrail::StartSplineMovement(){ }
 void AFGPipeBuilderTrail::PlayBuildEffect(){ }
 void AFGPipeBuilderTrail::EffectDone(){ }
-void AFGPipeBuilderTrail::BeginPlay(){ }
-void AFGPipeBuilderTrail::Tick(float DeltaTime){ }
+void AFGPipeBuilderTrail::BeginPlay(){ Super::BeginPlay(); }
+void AFGPipeBuilderTrail::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/FGPipeConnectionComponent.cpp
+++ b/Source/FactoryGame/Private/FGPipeConnectionComponent.cpp
@@ -16,7 +16,7 @@ void UFGPipeConnectionComponentBase::GetLifetimeReplicatedProps(TArray< FLifetim
 	DOREPLIFETIME(UFGPipeConnectionComponentBase, mConnectedComponent);
 }
 void UFGPipeConnectionComponentBase::OnComponentDestroyed(bool isDestroyingHierarchy){ }
-void UFGPipeConnectionComponentBase::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGPipeConnectionComponentBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGPipeConnectionComponentBase::SetConnection( UFGPipeConnectionComponentBase* toComponent){ }
 void UFGPipeConnectionComponentBase::ClearConnection(){ }
 bool UFGPipeConnectionComponentBase::IsConnected() const{ return bool(); }
@@ -32,7 +32,7 @@ UFGPipeConnectionComponent::UFGPipeConnectionComponent() : Super() {
 	this->mPipeNetworkID = -1;
 	this->mFluidDescriptor = nullptr;
 }
-void UFGPipeConnectionComponent::BeginPlay(){ }
+void UFGPipeConnectionComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGPipeConnectionComponent::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(UFGPipeConnectionComponent, mPipeNetworkID);

--- a/Source/FactoryGame/Private/FGPipeConnectionFactory.cpp
+++ b/Source/FactoryGame/Private/FGPipeConnectionFactory.cpp
@@ -6,8 +6,8 @@ UFGPipeConnectionFactory::UFGPipeConnectionFactory() : Super() {
 	this->mFluidBoxVolume = 5.0;
 	this->mApplyAdditionalPressure = true;
 }
-void UFGPipeConnectionFactory::BeginPlay(){ }
-void UFGPipeConnectionFactory::EndPlay(const EEndPlayReason::Type reason){ }
+void UFGPipeConnectionFactory::BeginPlay(){ Super::BeginPlay(); }
+void UFGPipeConnectionFactory::EndPlay(const EEndPlayReason::Type reason){ Super::EndPlay(reason); }
 FFluidBox* UFGPipeConnectionFactory::GetFluidBox(){ return nullptr; }
 TArray< UFGPipeConnectionComponent* > UFGPipeConnectionFactory::GetPipeConnections(){ return TArray<UFGPipeConnectionComponent*>(); }
 void UFGPipeConnectionFactory::OnDisconnectedFrom(){ }

--- a/Source/FactoryGame/Private/FGPipeNetwork.cpp
+++ b/Source/FactoryGame/Private/FGPipeNetwork.cpp
@@ -9,8 +9,8 @@ void AFGPipeNetwork::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& Out
 	DOREPLIFETIME(AFGPipeNetwork, mPipeNetworkID);
 	DOREPLIFETIME(AFGPipeNetwork, mFluidDescriptor);
 }
-void AFGPipeNetwork::BeginPlay(){ }
-void AFGPipeNetwork::EndPlay(EEndPlayReason::Type endPlayReason){ }
+void AFGPipeNetwork::BeginPlay(){ Super::BeginPlay(); }
+void AFGPipeNetwork::EndPlay(EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGPipeNetwork::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGPipeNetwork::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGPipeNetwork::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGPipeSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGPipeSubsystem.cpp
@@ -18,7 +18,7 @@ void AFGPipeSubsystem::PostLoadGame_Implementation(int32 saveVersion, int32 game
 void AFGPipeSubsystem::GatherDependencies_Implementation(TArray< UObject* >& out_dependentObjects){ }
 bool AFGPipeSubsystem::NeedTransform_Implementation(){ return bool(); }
 bool AFGPipeSubsystem::ShouldSave_Implementation() const{ return bool(); }
-void AFGPipeSubsystem::Tick(float dt){ }
+void AFGPipeSubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGPipeSubsystem::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 AFGPipeSubsystem* AFGPipeSubsystem::Get(UWorld* world){ return nullptr; }
 AFGPipeSubsystem* AFGPipeSubsystem::GetPipeSubsystem(UObject* worldContext){ return nullptr; }

--- a/Source/FactoryGame/Private/FGPipelineFlowIndicatorComponent.cpp
+++ b/Source/FactoryGame/Private/FGPipelineFlowIndicatorComponent.cpp
@@ -2,5 +2,5 @@
 
 #include "FGPipelineFlowIndicatorComponent.h"
 
-void UFGPipelineFlowIndicatorComponent::BeginPlay(){ }
+void UFGPipelineFlowIndicatorComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGPipelineFlowIndicatorComponent::OnFluidDescriptorSet_Implementation(TSubclassOf< UFGItemDescriptor > fluidDescriptor){ }

--- a/Source/FactoryGame/Private/FGPlayerController.cpp
+++ b/Source/FactoryGame/Private/FGPlayerController.cpp
@@ -47,9 +47,9 @@ void AFGPlayerController::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(AFGPlayerController, mDedicatedServerPrivilegeLevel);
 }
 void AFGPlayerController::PostInitializeComponents(){ Super::PostInitializeComponents(); }
-void AFGPlayerController::BeginPlay(){ }
-void AFGPlayerController::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGPlayerController::Destroyed(){ }
+void AFGPlayerController::BeginPlay(){ Super::BeginPlay(); }
+void AFGPlayerController::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGPlayerController::Destroyed(){ Super::Destroyed(); }
 void AFGPlayerController::PostRenderFor(APlayerController* PC, UCanvas* Canvas, FVector CameraPosition, FVector CameraDir){ }
 void AFGPlayerController::OnRep_PlayerState(){ }
 void AFGPlayerController::SetPawn(APawn* inPawn){ }

--- a/Source/FactoryGame/Private/FGPlayerControllerBase.cpp
+++ b/Source/FactoryGame/Private/FGPlayerControllerBase.cpp
@@ -15,7 +15,7 @@ void AFGPlayerControllerBase::GetLifetimeReplicatedProps(TArray<FLifetimePropert
 	DOREPLIFETIME(AFGPlayerControllerBase, mAdminInterface);
 	DOREPLIFETIME(AFGPlayerControllerBase, mReplicatedCheatManager);
 }
-void AFGPlayerControllerBase::BeginPlay(){ }
+void AFGPlayerControllerBase::BeginPlay(){ Super::BeginPlay(); }
 void AFGPlayerControllerBase::ClientRestart_Implementation(APawn* newPawn){ }
 void AFGPlayerControllerBase::AddCheats(bool force){ }
 void AFGPlayerControllerBase::SetIsUsingGamepad(bool newIsUsingGamepad){ }

--- a/Source/FactoryGame/Private/FGPlayerState.cpp
+++ b/Source/FactoryGame/Private/FGPlayerState.cpp
@@ -116,7 +116,7 @@ void AFGPlayerState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 	DOREPLIFETIME(AFGPlayerState, mPlayerSpecificSchematics);
 	DOREPLIFETIME(AFGPlayerState, mCentralStoragePinnedItems);
 }
-void AFGPlayerState::BeginPlay(){ }
+void AFGPlayerState::BeginPlay(){ Super::BeginPlay(); }
 void AFGPlayerState::CopyProperties(APlayerState* playerState){ }
 void AFGPlayerState::ClientInitialize(AController* C){ }
 void AFGPlayerState::RegisterPlayerWithSession(bool bWasFromInvite){ }

--- a/Source/FactoryGame/Private/FGPortableMiner.cpp
+++ b/Source/FactoryGame/Private/FGPortableMiner.cpp
@@ -38,8 +38,8 @@ AFGPortableMiner::AFGPortableMiner() : Super() {
 	this->PrimaryActorTick.TickInterval = 0.0;
 	this->bReplicates = true;
 }
-void AFGPortableMiner::BeginPlay(){ }
-void AFGPortableMiner::Tick(float dt){ }
+void AFGPortableMiner::BeginPlay(){ Super::BeginPlay(); }
+void AFGPortableMiner::Tick(float dt){ Super::Tick(dt); }
 void AFGPortableMiner::TickProducing(float dt){ }
 void AFGPortableMiner::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGPortableMiner::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGPowerCircuitWidget.cpp
+++ b/Source/FactoryGame/Private/FGPowerCircuitWidget.cpp
@@ -2,4 +2,4 @@
 
 #include "FGPowerCircuitWidget.h"
 
-void UFGPowerCircuitWidget::NativeTick(const FGeometry& myGeometry, float inDeltaTime){ }
+void UFGPowerCircuitWidget::NativeTick(const FGeometry& myGeometry, float inDeltaTime){ Super::NativeTick(myGeometry, inDeltaTime); }

--- a/Source/FactoryGame/Private/FGPriorityPowerSwitchInfo.cpp
+++ b/Source/FactoryGame/Private/FGPriorityPowerSwitchInfo.cpp
@@ -19,8 +19,8 @@ void AFGPriorityPowerSwitchInfo::GetLifetimeReplicatedProps(TArray< FLifetimePro
 	DOREPLIFETIME(AFGPriorityPowerSwitchInfo, mCircuitGroupID0);
 	DOREPLIFETIME(AFGPriorityPowerSwitchInfo, mCircuitGroupID1);
 }
-void AFGPriorityPowerSwitchInfo::BeginPlay(){ }
-void AFGPriorityPowerSwitchInfo::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGPriorityPowerSwitchInfo::BeginPlay(){ Super::BeginPlay(); }
+void AFGPriorityPowerSwitchInfo::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGPriorityPowerSwitchInfo::Init( AFGBuildablePriorityPowerSwitch* prioritySwitch){ }
 void AFGPriorityPowerSwitchInfo::SetPriority(int32 priority){ }
 void AFGPriorityPowerSwitchInfo::SetSwitchOn(bool on){ }

--- a/Source/FactoryGame/Private/FGProjectAssembly.cpp
+++ b/Source/FactoryGame/Private/FGProjectAssembly.cpp
@@ -30,11 +30,11 @@ void AFGProjectAssembly::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& O
 	DOREPLIFETIME(AFGProjectAssembly, mIsMovingToTarget);
 	DOREPLIFETIME(AFGProjectAssembly, mTargetLocation);
 }
-void AFGProjectAssembly::BeginPlay(){ }
-void AFGProjectAssembly::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGProjectAssembly::BeginPlay(){ Super::BeginPlay(); }
+void AFGProjectAssembly::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGProjectAssembly::OnGamePhaseChanged_Implementation(UFGGamePhase* currentGamePhase){ }
 void AFGProjectAssembly::BeginMoveToTarget_Implementation(){ }
 void AFGProjectAssembly::OnTargetReached_Implementation(){ }
-void AFGProjectAssembly::Tick(float DeltaSeconds){ }
+void AFGProjectAssembly::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGProjectAssembly::UpdatePosition_Implementation(){ }
 void AFGProjectAssembly::OnRep_IsMovingToTarget(){ }

--- a/Source/FactoryGame/Private/FGProjectile.cpp
+++ b/Source/FactoryGame/Private/FGProjectile.cpp
@@ -58,7 +58,7 @@ AFGProjectile::AFGProjectile() : Super() {
 	this->bReplicateUsingRegisteredSubObjectList = true;
 	this->RootComponent = mCollisionComp;
 }
-void AFGProjectile::Tick(float DeltaSeconds){ }
+void AFGProjectile::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGProjectile::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGProjectile, mProjectileLifespan);

--- a/Source/FactoryGame/Private/FGProximitySubsystem.cpp
+++ b/Source/FactoryGame/Private/FGProximitySubsystem.cpp
@@ -30,6 +30,6 @@ void AFGProximitySubsystem::OnEnteredMapArea_Implementation( AFGPlayerController
 void AFGProximitySubsystem::OnPawnChanged_Implementation( APawn* newPawn){ }
 UParticleSystem* AFGProximitySubsystem::GetParticleSystemFromMapArea(TSubclassOf<  UFGMapArea > inArea){ return nullptr; }
 void AFGProximitySubsystem::SpawnPooledDecal(const UObject* WorldContextObject,  UMaterialInterface* DecalMaterial, FVector DecalSize, FVector Location, FRotator Rotation , float LifeSpan){ }
-void AFGProximitySubsystem::BeginPlay(){ }
-void AFGProximitySubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGProximitySubsystem::Tick(float DeltaTime){ }
+void AFGProximitySubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGProximitySubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGProximitySubsystem::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/FGRadioactiveActor.cpp
+++ b/Source/FactoryGame/Private/FGRadioactiveActor.cpp
@@ -7,4 +7,4 @@ AFGRadioactiveActor::AFGRadioactiveActor() : Super() {
 	this->mRadioactiveDecay = 0.0;
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 }
-void AFGRadioactiveActor::BeginPlay(){ }
+void AFGRadioactiveActor::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGRadioactivitySubsystem.cpp
+++ b/Source/FactoryGame/Private/FGRadioactivitySubsystem.cpp
@@ -11,8 +11,8 @@ AFGRadioactivitySubsystem::AFGRadioactivitySubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGRadioactivitySubsystem::BeginPlay(){ }
-void AFGRadioactivitySubsystem::Tick(float dt){ }
+void AFGRadioactivitySubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGRadioactivitySubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGRadioactivitySubsystem::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 void AFGRadioactivitySubsystem::OnActorSpawned(AActor* spawnedActor){ }
 void AFGRadioactivitySubsystem::OnActorDestroyed(AActor* destroyedActor){ }

--- a/Source/FactoryGame/Private/FGRailroadSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGRailroadSubsystem.cpp
@@ -32,9 +32,9 @@ void AFGRailroadSubsystem::GetLifetimeReplicatedProps(TArray< FLifetimeProperty 
 	DOREPLIFETIME(AFGRailroadSubsystem, mTrains);
 }
 void AFGRailroadSubsystem::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGRailroadSubsystem::BeginPlay(){ }
-void AFGRailroadSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGRailroadSubsystem::Tick(float dt){ }
+void AFGRailroadSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGRailroadSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGRailroadSubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGRailroadSubsystem::DisplayDebug( UCanvas* canvas, const  FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 void AFGRailroadSubsystem::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGRailroadSubsystem::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGRailroadVehicle.cpp
+++ b/Source/FactoryGame/Private/FGRailroadVehicle.cpp
@@ -27,10 +27,10 @@ void AFGRailroadVehicle::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >&
 	DOREPLIFETIME(AFGRailroadVehicle, mTrackPosition);
 	DOREPLIFETIME(AFGRailroadVehicle, mIsDerailed);
 }
-void AFGRailroadVehicle::BeginPlay(){ }
-void AFGRailroadVehicle::Destroyed(){ }
+void AFGRailroadVehicle::BeginPlay(){ Super::BeginPlay(); }
+void AFGRailroadVehicle::Destroyed(){ Super::Destroyed(); }
 void AFGRailroadVehicle::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGRailroadVehicle::Tick(float dt){ }
+void AFGRailroadVehicle::Tick(float dt){ Super::Tick(dt); }
 bool AFGRailroadVehicle::CanDismantle_Implementation() const{ return bool(); }
 void AFGRailroadVehicle::GetDismantleDisqualifiers_Implementation(TArray<TSubclassOf<UFGConstructDisqualifier>>& out_dismantleDisqualifiers, const TArray<AActor*>& allSelectedActors) const{ }
 void AFGRailroadVehicle::GainedSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/FGRainOcclusionActor.cpp
+++ b/Source/FactoryGame/Private/FGRainOcclusionActor.cpp
@@ -17,8 +17,8 @@ AFGRainOcclusionActor::AFGRainOcclusionActor() : Super() {
 	this->mRampShapeOccluder->SetupAttachment(RootComponent);
 	this->mTriangleShapeOccluder->SetupAttachment(RootComponent);
 }
-void AFGRainOcclusionActor::Tick(float DeltaSeconds){ }
-void AFGRainOcclusionActor::BeginPlay(){ }
+void AFGRainOcclusionActor::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGRainOcclusionActor::BeginPlay(){ Super::BeginPlay(); }
 void AFGRainOcclusionActor::ForceUpdateOcclusionShapes(const FVector& Location, const float& Range){ }
 void AFGRainOcclusionActor::OnTraceCompleted(const FTraceHandle& Handle, FOverlapDatum& Data){ }
 void AFGRainOcclusionActor::AddShape(AFGBuildable* Buildable){ }

--- a/Source/FactoryGame/Private/FGRecipeManager.cpp
+++ b/Source/FactoryGame/Private/FGRecipeManager.cpp
@@ -19,7 +19,7 @@ void AFGRecipeManager::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Out
 	DOREPLIFETIME(AFGRecipeManager, mNumAllRecipes);
 	DOREPLIFETIME(AFGRecipeManager, mAvailableCustomizationRecipes);
 }
-void AFGRecipeManager::BeginPlay(){ }
+void AFGRecipeManager::BeginPlay(){ Super::BeginPlay(); }
 void AFGRecipeManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGRecipeManager::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGRecipeManager::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGRenderTargetStage.cpp
+++ b/Source/FactoryGame/Private/FGRenderTargetStage.cpp
@@ -15,7 +15,7 @@ AFGRenderTargetStage::AFGRenderTargetStage() : Super() {
 	this->mSceneCaptureComponent->SetupAttachment(RootComponent);
 	this->mStage->SetupAttachment(RootComponent);
 }
-void AFGRenderTargetStage::BeginPlay(){ }
+void AFGRenderTargetStage::BeginPlay(){ Super::BeginPlay(); }
 void AFGRenderTargetStage::BeginCapture(){ }
 void AFGRenderTargetStage::EndCapture(){ }
 void AFGRenderTargetStage::CaptureOnce(){ }

--- a/Source/FactoryGame/Private/FGResearchMachine.cpp
+++ b/Source/FactoryGame/Private/FGResearchMachine.cpp
@@ -26,6 +26,6 @@ void UFGResearchMachine::SetResearchMeshCurveScale(UCurveFloat* curveScale){ }
 void UFGResearchMachine::OnResearchStarted(TSubclassOf<class UFGSchematic> schematic){ }
 void UFGResearchMachine::OnResearchConcluded(TSubclassOf<class UFGSchematic> schematic){ }
 void UFGResearchMachine::SetMachineUser( AFGCharacterPlayer* player){ }
-void UFGResearchMachine::BeginPlay(){ }
-void UFGResearchMachine::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGResearchMachine::BeginPlay(){ Super::BeginPlay(); }
+void UFGResearchMachine::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGResearchMachine::OnRep_ResearchMesh(){ }

--- a/Source/FactoryGame/Private/FGResearchManager.cpp
+++ b/Source/FactoryGame/Private/FGResearchManager.cpp
@@ -33,7 +33,7 @@ void AFGResearchManager::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& O
 	DOREPLIFETIME(AFGResearchManager, mCanRerollHardDrives);
 }
 void AFGResearchManager::PreInitializeComponents(){ Super::PreInitializeComponents(); }
-void AFGResearchManager::BeginPlay(){ }
+void AFGResearchManager::BeginPlay(){ Super::BeginPlay(); }
 AFGResearchManager* AFGResearchManager::Get( UWorld* world){ return nullptr; }
 AFGResearchManager* AFGResearchManager::Get( UObject* worldContext){ return nullptr; }
 void AFGResearchManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGResourceNodeGeyser.cpp
+++ b/Source/FactoryGame/Private/FGResourceNodeGeyser.cpp
@@ -5,4 +5,4 @@
 AFGResourceNodeGeyser::AFGResourceNodeGeyser() : Super() {
 
 }
-void AFGResourceNodeGeyser::BeginPlay(){ }
+void AFGResourceNodeGeyser::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/FGResourceSinkSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGResourceSinkSubsystem.cpp
@@ -32,8 +32,8 @@ void AFGResourceSinkSubsystem::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGResourceSinkSubsystem, mNumResourceSinkCoupons);
 	DOREPLIFETIME(AFGResourceSinkSubsystem, mGlobalPointHistoryValues);
 }
-void AFGResourceSinkSubsystem::BeginPlay(){ }
-void AFGResourceSinkSubsystem::Tick(float DeltaSeconds){ }
+void AFGResourceSinkSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGResourceSinkSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGResourceSinkSubsystem::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 AFGResourceSinkSubsystem* AFGResourceSinkSubsystem::Get(UWorld* world){ return nullptr; }
 AFGResourceSinkSubsystem* AFGResourceSinkSubsystem::Get(UObject* worldContext){ return nullptr; }

--- a/Source/FactoryGame/Private/FGScannableSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGScannableSubsystem.cpp
@@ -10,8 +10,8 @@ AFGScannableSubsystem* AFGScannableSubsystem::Get(UObject* worldContext){ return
 void AFGScannableSubsystem::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 }
-void AFGScannableSubsystem::BeginPlay(){ }
-void AFGScannableSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGScannableSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGScannableSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 void AFGScannableSubsystem::RegisterRadarTower( AFGBuildableRadarTower* radarTower){ }
 void AFGScannableSubsystem::UnRegisterRadarTower( AFGBuildableRadarTower* radarTower){ }
 void AFGScannableSubsystem::OnLevelPlacedActorDestroyed(AActor* destroyedActor){ }

--- a/Source/FactoryGame/Private/FGSchematicManager.cpp
+++ b/Source/FactoryGame/Private/FGSchematicManager.cpp
@@ -32,9 +32,9 @@ void AFGSchematicManager::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(AFGSchematicManager, mShipLandTimeStamp);
 }
 void AFGSchematicManager::PreInitializeComponents(){ Super::PreInitializeComponents(); }
-void AFGSchematicManager::BeginPlay(){ }
-void AFGSchematicManager::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGSchematicManager::Tick(float dt){ }
+void AFGSchematicManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGSchematicManager::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGSchematicManager::Tick(float dt){ Super::Tick(dt); }
 void AFGSchematicManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGSchematicManager::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGSchematicManager::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGSignPixelInstanceManager.cpp
+++ b/Source/FactoryGame/Private/FGSignPixelInstanceManager.cpp
@@ -5,7 +5,7 @@
 UFGSignPixelInstanceManager::UFGSignPixelInstanceManager() : Super() {
 	this->mInstanceComponent = nullptr;
 }
-void UFGSignPixelInstanceManager::BeginPlay(){ }
+void UFGSignPixelInstanceManager::BeginPlay(){ Super::BeginPlay(); }
 UFGSignPixelInstanceManager::FSignHandle UFGSignPixelInstanceManager::AddPixelSign( AFGBuildablePixelSign* pixelSign){ return FSignHandle(); }
 void UFGSignPixelInstanceManager::RemovePixelSign(const FSignHandle& signHandle){ }
 void UFGSignPixelInstanceManager::CreateHierarchicalInstancingComponent(UStaticMesh* staticMesh){ }

--- a/Source/FactoryGame/Private/FGSignSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGSignSubsystem.cpp
@@ -32,8 +32,8 @@ AFGSignSubsystem::AFGSignSubsystem() : Super() {
 	this->SetHidden(false);
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
 }
-void AFGSignSubsystem::BeginPlay(){ }
-void AFGSignSubsystem::Tick(float DeltaSeconds){ }
+void AFGSignSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGSignSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGSignSubsystem::UpdateAndSortPendingSigns(){ }
 void AFGSignSubsystem::AddWidgetSign(AFGBuildableWidgetSign* widgetSign){ }
 void AFGSignSubsystem::RemoveWidgetSign(AFGBuildableWidgetSign* widgetSign){ }

--- a/Source/FactoryGame/Private/FGSignificanceActor.cpp
+++ b/Source/FactoryGame/Private/FGSignificanceActor.cpp
@@ -13,6 +13,6 @@ AFGSignificanceActor::AFGSignificanceActor() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGSignificanceActor::BeginPlay(){ }
-void AFGSignificanceActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGSignificanceActor::Tick(float DeltaTime){ }
+void AFGSignificanceActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGSignificanceActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGSignificanceActor::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/FGSkySphere.cpp
+++ b/Source/FactoryGame/Private/FGSkySphere.cpp
@@ -80,8 +80,8 @@ AFGSkySphere::AFGSkySphere() : Super() {
 void AFGSkySphere::PostActorCreated(){ Super::PostActorCreated(); }
 void AFGSkySphere::PostLoad(){ Super::PostLoad(); }
 void AFGSkySphere::BeginDestroy(){ Super::BeginDestroy(); }
-void AFGSkySphere::Tick(float DeltaTime){ }
-void AFGSkySphere::BeginPlay(){ }
+void AFGSkySphere::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
+void AFGSkySphere::BeginPlay(){ Super::BeginPlay(); }
 void AFGSkySphere::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGSkySphere, mCurrentSelectedWeather);

--- a/Source/FactoryGame/Private/FGSporeFlower.cpp
+++ b/Source/FactoryGame/Private/FGSporeFlower.cpp
@@ -10,8 +10,8 @@ void AFGSporeFlower::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 }
-void AFGSporeFlower::BeginPlay(){ }
-void AFGSporeFlower::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGSporeFlower::BeginPlay(){ Super::BeginPlay(); }
+void AFGSporeFlower::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 float AFGSporeFlower::TakeDamage(float damage,  FDamageEvent const& damageEvent, AController* eventInstigator, AActor* damageCauser){ return float(); }
 void AFGSporeFlower::GainedSignificance_Implementation(){ }
 void AFGSporeFlower::LostSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/FGStartingPod.cpp
+++ b/Source/FactoryGame/Private/FGStartingPod.cpp
@@ -35,8 +35,8 @@ void AFGStartingPod::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGStartingPod, mDropPodSpawnLocation);
 }
-void AFGStartingPod::BeginPlay(){ }
-void AFGStartingPod::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGStartingPod::BeginPlay(){ Super::BeginPlay(); }
+void AFGStartingPod::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 FVector AFGStartingPod::GetRefundSpawnLocationAndArea_Implementation(const FVector& aimHitLocation, float& out_radius) const{ return FVector(); }
 bool AFGStartingPod::CanDismantle_Implementation() const{ return bool(); }
 void AFGStartingPod::GetDismantleRefund_Implementation(TArray< FInventoryStack >& out_refund, bool noBuildCostEnabled) const{ }

--- a/Source/FactoryGame/Private/FGStorySubsystem.cpp
+++ b/Source/FactoryGame/Private/FGStorySubsystem.cpp
@@ -14,7 +14,7 @@ AFGStorySubsystem::AFGStorySubsystem() : Super() {
 }
 AFGStorySubsystem* AFGStorySubsystem::Get(UWorld* world){ return nullptr; }
 AFGStorySubsystem* AFGStorySubsystem::Get(UObject* worldContext){ return nullptr; }
-void AFGStorySubsystem::BeginPlay(){ }
+void AFGStorySubsystem::BeginPlay(){ Super::BeginPlay(); }
 void AFGStorySubsystem::OnOnboardingStepUpdated( UFGOnboardingStep* newOnboardingStep){ }
 void AFGStorySubsystem::OnSchematicsPurchased(TArray< TSubclassOf< UFGSchematic > > newSchematics,  AFGCharacterPlayer* purchaseInstigator){ }
 void AFGStorySubsystem::OnGamePhaseChanged(UFGGamePhase* currentGamePhase){ }

--- a/Source/FactoryGame/Private/FGTimeSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGTimeSubsystem.cpp
@@ -29,8 +29,8 @@ AFGTimeOfDaySubsystem::AFGTimeOfDaySubsystem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGTimeOfDaySubsystem::BeginPlay(){ }
-void AFGTimeOfDaySubsystem::Tick(float dt){ }
+void AFGTimeOfDaySubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGTimeOfDaySubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGTimeOfDaySubsystem::DisplayDebug(UCanvas* Canvas, const FDebugDisplayInfo& DebugDisplay, float& YL, float& YPos){ }
 void AFGTimeOfDaySubsystem::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGTimeOfDaySubsystem::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGTrain.cpp
+++ b/Source/FactoryGame/Private/FGTrain.cpp
@@ -85,10 +85,10 @@ void AFGTrain::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifeti
 	DOREPLIFETIME(AFGTrain, mIsDerailed);
 	DOREPLIFETIME(AFGTrain, mTrainReplicationActor);
 }
-void AFGTrain::Tick(float dt){ }
-void AFGTrain::BeginPlay(){ }
-void AFGTrain::Destroyed(){ }
-void AFGTrain::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGTrain::Tick(float dt){ Super::Tick(dt); }
+void AFGTrain::BeginPlay(){ Super::BeginPlay(); }
+void AFGTrain::Destroyed(){ Super::Destroyed(); }
+void AFGTrain::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGTrain::IsLevelBoundsRelevant() const{ return bool(); }
 void AFGTrain::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGTrain::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGTrainReplicationActor.cpp
+++ b/Source/FactoryGame/Private/FGTrainReplicationActor.cpp
@@ -19,8 +19,8 @@ void AFGTrainReplicationActor::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGTrainReplicationActor, mVehicles);
 	DOREPLIFETIME(AFGTrainReplicationActor, mLastServerSimulationState);
 }
-void AFGTrainReplicationActor::BeginPlay(){ }
-void AFGTrainReplicationActor::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGTrainReplicationActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGTrainReplicationActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 UClass* AFGTrainReplicationActor::GetConcreteClassForTrainSize(int32 numVehicles){ return nullptr; }
 void AFGTrainReplicationActor::SetVehicles(TArray< AFGRailroadVehicle* > vehicles){ }
 const TArray< class AFGRailroadVehicle* >& AFGTrainReplicationActor::GetVehicles() const{ return *(new TArray< class AFGRailroadVehicle* >); }

--- a/Source/FactoryGame/Private/FGTrainStationIdentifier.cpp
+++ b/Source/FactoryGame/Private/FGTrainStationIdentifier.cpp
@@ -17,8 +17,8 @@ void AFGTrainStationIdentifier::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	DOREPLIFETIME(AFGTrainStationIdentifier, mTrackGraphID);
 	DOREPLIFETIME(AFGTrainStationIdentifier, mStationName);
 }
-void AFGTrainStationIdentifier::BeginPlay(){ }
-void AFGTrainStationIdentifier::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGTrainStationIdentifier::BeginPlay(){ Super::BeginPlay(); }
+void AFGTrainStationIdentifier::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGTrainStationIdentifier::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGTrainStationIdentifier::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGTrainStationIdentifier::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/FGTutorialIntroManager.cpp
+++ b/Source/FactoryGame/Private/FGTutorialIntroManager.cpp
@@ -54,7 +54,7 @@ void AFGTutorialIntroManager::GetLifetimeReplicatedProps(TArray<FLifetimePropert
 	DOREPLIFETIME(AFGTutorialIntroManager, mStartingPod);
 	DOREPLIFETIME(AFGTutorialIntroManager, mTradingPostLevel);
 }
-void AFGTutorialIntroManager::Tick(float DeltaTime){ }
+void AFGTutorialIntroManager::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGTutorialIntroManager::PostInitializeComponents(){ Super::PostInitializeComponents(); }
 void AFGTutorialIntroManager::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGTutorialIntroManager::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
@@ -83,7 +83,7 @@ void AFGTutorialIntroManager::ResetHubTutorial(){ }
 void AFGTutorialIntroManager::SetCanSkipTutorialIntro(bool canSkip){ }
 void AFGTutorialIntroManager::OnCodexOpened(){ }
 void AFGTutorialIntroManager::SkipOnboarding(){ }
-void AFGTutorialIntroManager::BeginPlay(){ }
+void AFGTutorialIntroManager::BeginPlay(){ Super::BeginPlay(); }
 void AFGTutorialIntroManager::OnBuildingBuiltGlobal( AFGBuildable* buildable){ }
 void AFGTutorialIntroManager::OnSchematicPurchased(TSubclassOf< UFGSchematic > newSchematic){ }
 void AFGTutorialIntroManager::OnItemPickuped(AFGPlayerState* playerState, const FItemAmount& totalAmountPickuped){ }

--- a/Source/FactoryGame/Private/FGUnlockPickup.cpp
+++ b/Source/FactoryGame/Private/FGUnlockPickup.cpp
@@ -13,8 +13,8 @@ void AFGUnlockPickup::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutL
 	DOREPLIFETIME(AFGUnlockPickup, mPickupState);
 }
 void AFGUnlockPickup::Serialize(FArchive& ar){ Super::Serialize(ar); }
-void AFGUnlockPickup::BeginPlay(){ }
-void AFGUnlockPickup::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGUnlockPickup::BeginPlay(){ Super::BeginPlay(); }
+void AFGUnlockPickup::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGUnlockPickup::ShouldSave_Implementation() const{ return bool(); }
 void AFGUnlockPickup::UpdateUseState_Implementation( AFGCharacterPlayer* byCharacter, const FVector& atLocation,  UPrimitiveComponent* componentHit, FUseState& out_useState){ }
 void AFGUnlockPickup::OnUse_Implementation( AFGCharacterPlayer* byCharacter, const FUseState& state){ }

--- a/Source/FactoryGame/Private/FGVehicle.cpp
+++ b/Source/FactoryGame/Private/FGVehicle.cpp
@@ -63,10 +63,10 @@ AFGVehicle::AFGVehicle() : Super() {
 	this->bNetLoadOnClient = false;
 	this->RootComponent = mMesh;
 }
-void AFGVehicle::BeginPlay(){ }
-void AFGVehicle::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGVehicle::Destroyed(){ }
-void AFGVehicle::Tick(float dt){ }
+void AFGVehicle::BeginPlay(){ Super::BeginPlay(); }
+void AFGVehicle::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGVehicle::Destroyed(){ Super::Destroyed(); }
+void AFGVehicle::Tick(float dt){ Super::Tick(dt); }
 float AFGVehicle::TakeDamage(float DamageAmount,  FDamageEvent const& DamageEvent,  AController* EventInstigator, AActor* DamageCauser){ return float(); }
 void AFGVehicle::DisplayDebug( UCanvas* canvas, const FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 UPawnMovementComponent* AFGVehicle::GetMovementComponent() const{ return nullptr; }

--- a/Source/FactoryGame/Private/FGVehicleSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGVehicleSubsystem.cpp
@@ -49,9 +49,9 @@ void AFGVehicleSubsystem::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >
 	DOREPLIFETIME(AFGVehicleSubsystem, mWheeledVehicles);
 	DOREPLIFETIME(AFGVehicleSubsystem, mSavedPaths);
 }
-void AFGVehicleSubsystem::BeginPlay(){ }
-void AFGVehicleSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGVehicleSubsystem::Tick(float dt){ }
+void AFGVehicleSubsystem::BeginPlay(){ Super::BeginPlay(); }
+void AFGVehicleSubsystem::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGVehicleSubsystem::Tick(float dt){ Super::Tick(dt); }
 AFGVehicleSubsystem* AFGVehicleSubsystem::Get(UWorld* world){ return nullptr; }
 AFGVehicleSubsystem* AFGVehicleSubsystem::Get(UObject* worldContext){ return nullptr; }
 void AFGVehicleSubsystem::TickVehicleSimulation(float dt){ }

--- a/Source/FactoryGame/Private/FGVertexAnimatedMeshComponent.cpp
+++ b/Source/FactoryGame/Private/FGVertexAnimatedMeshComponent.cpp
@@ -36,8 +36,8 @@ UFGVertexAnimatedMeshComponent::UFGVertexAnimatedMeshComponent() : Super() {
 	this->mBlockInstancing = true;
 	this->WorldPositionOffsetDisableDistance = 100000;
 }
-void UFGVertexAnimatedMeshComponent::BeginPlay(){ }
-void UFGVertexAnimatedMeshComponent::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGVertexAnimatedMeshComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGVertexAnimatedMeshComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGVertexAnimatedMeshComponent::GainedSignificance_Implementation(){ }
 void UFGVertexAnimatedMeshComponent::LostSignificance_Implementation(){ }
 bool UFGVertexAnimatedMeshComponent::ShouldAddToSignificanceManager() const{ return bool(); }

--- a/Source/FactoryGame/Private/FGVolumeMapArea.cpp
+++ b/Source/FactoryGame/Private/FGVolumeMapArea.cpp
@@ -8,6 +8,6 @@ void AFGVolumeMapArea::CheckForErrors(){ Super::CheckForErrors(); }
 AFGVolumeMapArea::AFGVolumeMapArea() : Super() {
 	this->mMapArea = nullptr;
 }
-void AFGVolumeMapArea::BeginPlay(){ }
+void AFGVolumeMapArea::BeginPlay(){ Super::BeginPlay(); }
 void AFGVolumeMapArea::OnPrimitiveComponentEntered(UPrimitiveComponent* overlappedComp, AActor* other, UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool fromSweep, const FHitResult& sweepResult){ }
 void AFGVolumeMapArea::OnPawnEntered(APawn* pawn, const FHitResult& enterInfo){ }

--- a/Source/FactoryGame/Private/FGWaterVolume.cpp
+++ b/Source/FactoryGame/Private/FGWaterVolume.cpp
@@ -25,8 +25,8 @@ AFGWaterVolume::AFGWaterVolume() : Super() {
 	this->bWaterVolume = true;
 }
 void AFGWaterVolume::OnConstruction(const FTransform& transform){ }
-void AFGWaterVolume::BeginPlay(){ }
-void AFGWaterVolume::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGWaterVolume::BeginPlay(){ Super::BeginPlay(); }
+void AFGWaterVolume::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 bool AFGWaterVolume::IsOverlapInVolume(const  USceneComponent& testComponent) const{ return bool(); }
 void AFGWaterVolume::GainedSignificance_Implementation(){ }
 void AFGWaterVolume::LostSignificance_Implementation(){ }

--- a/Source/FactoryGame/Private/FGWeatherReaction.cpp
+++ b/Source/FactoryGame/Private/FGWeatherReaction.cpp
@@ -13,7 +13,7 @@ AFGWeatherReaction::AFGWeatherReaction() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGWeatherReaction::Tick(float DeltaSeconds){ }
-void AFGWeatherReaction::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGWeatherReaction::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
+void AFGWeatherReaction::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
 void AFGWeatherReaction::StartWeatherState_Implementation(AFGSkySphere* SkySphere){ }
 void AFGWeatherReaction::EndWeatherState_Implementation(AFGSkySphere* SkySphere){ }

--- a/Source/FactoryGame/Private/FGWorldEventActor.cpp
+++ b/Source/FactoryGame/Private/FGWorldEventActor.cpp
@@ -12,8 +12,8 @@ AFGWorldEventActor::AFGWorldEventActor() : Super() {
 	this->mState = EWorldEventState::Inactive;
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 }
-void AFGWorldEventActor::BeginPlay(){ }
-void AFGWorldEventActor::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGWorldEventActor::BeginPlay(){ Super::BeginPlay(); }
+void AFGWorldEventActor::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGWorldEventActor::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGWorldEventActor, mState);

--- a/Source/FactoryGame/Private/FGWorldEventSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGWorldEventSubsystem.cpp
@@ -13,7 +13,7 @@ AFGWorldEventSubsystem::AFGWorldEventSubsystem() : Super() {
 	this->mAllowAutomaticWorldEvents = true;
 	this->mAutomaticWorldEventActiveLimit = 3;
 }
-void AFGWorldEventSubsystem::Tick(float dt){ }
+void AFGWorldEventSubsystem::Tick(float dt){ Super::Tick(dt); }
 void AFGWorldEventSubsystem::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGWorldEventSubsystem, mWorldEventActors);

--- a/Source/FactoryGame/Private/FGWorldGridGeneratorActor.cpp
+++ b/Source/FactoryGame/Private/FGWorldGridGeneratorActor.cpp
@@ -10,5 +10,5 @@ AFGWorldGridGeneratorActor::AFGWorldGridGeneratorActor() : Super() {
 	this->mWorldGridMin = FVector2D::ZeroVector;
 	this->mWorldGridMax = FVector2D::ZeroVector;
 }
-void AFGWorldGridGeneratorActor::BeginPlay(){ }
+void AFGWorldGridGeneratorActor::BeginPlay(){ Super::BeginPlay(); }
 void AFGWorldGridGeneratorActor::GenerateWorldGrid(TArray< FFGWorldGridCellData >& CellData, FVector2D& GridMin, FVector2D& GridMax) const{ }

--- a/Source/FactoryGame/Private/FGWorldGridSubsystem.cpp
+++ b/Source/FactoryGame/Private/FGWorldGridSubsystem.cpp
@@ -44,5 +44,5 @@ TArray< const FFGWorldGridCell* > AFGWorldGridSubsystem::GetCellNeighboursFromIn
 TArray< int32 > AFGWorldGridSubsystem::GetCellNeighbourIndicesFromIndex(int32 Index) const{ return TArray<int32>(); }
 FVector2D AFGWorldGridSubsystem::GetWorldGridSize() const{ return FVector2D(); }
 FVector2D AFGWorldGridSubsystem::GetCellSize() const{ return FVector2D(); }
-void AFGWorldGridSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGWorldGridSubsystem::Tick(float DeltaSeconds){ }
+void AFGWorldGridSubsystem::EndPlay(const EEndPlayReason::Type EndPlayReason){ Super::EndPlay(EndPlayReason); }
+void AFGWorldGridSubsystem::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }

--- a/Source/FactoryGame/Private/Hologram/FGBeamHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGBeamHologram.cpp
@@ -13,7 +13,7 @@ AFGBeamHologram::AFGBeamHologram() : Super() {
 	this->mNeedsValidFloor = false;
 	this->mAllowEdgePlacementInDesignerEvenOnIntersect = true;
 }
-void AFGBeamHologram::BeginPlay(){ }
+void AFGBeamHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGBeamHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBeamHologram, mCurrentLength);

--- a/Source/FactoryGame/Private/Hologram/FGBlueprintHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGBlueprintHologram.cpp
@@ -15,7 +15,7 @@ AFGBlueprintHologram::AFGBlueprintHologram() : Super() {
 	this->mBlueprintDirectionMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Blueprint Direction Mesh"));
 	this->mBlueprintDirectionMesh->SetupAttachment(RootComponent);
 }
-void AFGBlueprintHologram::BeginPlay(){ }
+void AFGBlueprintHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGBlueprintHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBlueprintHologram, mBlueprintDescName);

--- a/Source/FactoryGame/Private/Hologram/FGBuildableDroneHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGBuildableDroneHologram.cpp
@@ -6,8 +6,8 @@
 AFGBuildableDroneHologram::AFGBuildableDroneHologram() : Super() {
 	this->mSnappedStation = nullptr;
 }
-void AFGBuildableDroneHologram::BeginPlay(){ }
-void AFGBuildableDroneHologram::Destroyed(){ }
+void AFGBuildableDroneHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGBuildableDroneHologram::Destroyed(){ Super::Destroyed(); }
 void AFGBuildableDroneHologram::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGBuildableDroneHologram, mSnappedStation);

--- a/Source/FactoryGame/Private/Hologram/FGBuildableHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGBuildableHologram.cpp
@@ -24,7 +24,7 @@ AFGBuildableHologram::AFGBuildableHologram() : Super() {
 	this->mUseBuildClearanceOverlapSnapp = true;
 	this->mCanNudgeHologram = true;
 }
-void AFGBuildableHologram::BeginPlay(){ }
+void AFGBuildableHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGBuildableHologram::SetBuildableClass(TSubclassOf<  AFGBuildable > buildableClass){ }
 bool AFGBuildableHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGBuildableHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGCeilingLightHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGCeilingLightHologram.cpp
@@ -6,7 +6,7 @@ AFGCeilingLightHologram::AFGCeilingLightHologram() : Super() {
 	this->mNeedsValidFloor = false;
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGCeilingLightHologram::BeginPlay(){ }
+void AFGCeilingLightHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGCeilingLightHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGCeilingLightHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 void AFGCeilingLightHologram::CheckValidPlacement(){ }

--- a/Source/FactoryGame/Private/Hologram/FGConveyorAttachmentHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGConveyorAttachmentHologram.cpp
@@ -13,7 +13,7 @@ AFGConveyorAttachmentHologram::AFGConveyorAttachmentHologram() : Super() {
 	this->mSnappedConveyorOffset = 0.0;
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGConveyorAttachmentHologram::BeginPlay(){ }
+void AFGConveyorAttachmentHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGConveyorAttachmentHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGConveyorAttachmentHologram, mSnappedConveyor);

--- a/Source/FactoryGame/Private/Hologram/FGConveyorBeltHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGConveyorBeltHologram.cpp
@@ -42,7 +42,7 @@ void AFGConveyorBeltHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProper
 	DOREPLIFETIME(AFGConveyorBeltHologram, mUpgradedConveyorBelt);
 	DOREPLIFETIME(AFGConveyorBeltHologram, mConnectionArrowComponentDirection);
 }
-void AFGConveyorBeltHologram::BeginPlay(){ }
+void AFGConveyorBeltHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGConveyorBeltHologram::TryUpgrade(const FHitResult& hitResult){ return bool(); }
 void AFGConveyorBeltHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 bool AFGConveyorBeltHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGConveyorLiftHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGConveyorLiftHologram.cpp
@@ -33,7 +33,7 @@ void AFGConveyorLiftHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProper
 	DOREPLIFETIME(AFGConveyorLiftHologram, mSnappedPassthroughs);
 	DOREPLIFETIME(AFGConveyorLiftHologram, mArrowDirection);
 }
-void AFGConveyorLiftHologram::BeginPlay(){ }
+void AFGConveyorLiftHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGConveyorLiftHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 void AFGConveyorLiftHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 bool AFGConveyorLiftHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGConveyorPoleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGConveyorPoleHologram.cpp
@@ -6,6 +6,6 @@ AFGConveyorPoleHologram::AFGConveyorPoleHologram() : Super() {
 	this->mSnapConnection = nullptr;
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGConveyorPoleHologram::BeginPlay(){ }
+void AFGConveyorPoleHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGConveyorPoleHologram::SnapToConnection(UFGFactoryConnectionComponent* connection,  AFGConveyorBeltHologram* parentConveyor){ }
 void AFGConveyorPoleHologram::SetSnappBuilding( AFGBuildable* snappedBuilding){ }

--- a/Source/FactoryGame/Private/Hologram/FGCornerWallHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGCornerWallHologram.cpp
@@ -5,5 +5,5 @@
 AFGCornerWallHologram::AFGCornerWallHologram() : Super() {
 
 }
-void AFGCornerWallHologram::BeginPlay(){ }
+void AFGCornerWallHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGCornerWallHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGDecorHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGDecorHologram.cpp
@@ -7,7 +7,7 @@ void AFGDecorHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& O
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGDecorHologram, mDecorMesh);
 }
-void AFGDecorHologram::BeginPlay(){ }
+void AFGDecorHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGDecorHologram::CheckValidPlacement(){ }
 void AFGDecorHologram::ConfigureActor( AFGBuildable* inBuildable) const{ }
 USceneComponent* AFGDecorHologram::SetupComponent(USceneComponent* attachParent, UActorComponent* componentTemplate, const FName& componentName, const FName& attachSocketName){ return nullptr; }

--- a/Source/FactoryGame/Private/Hologram/FGFactoryBuildingHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGFactoryBuildingHologram.cpp
@@ -10,7 +10,7 @@ AFGFactoryBuildingHologram::AFGFactoryBuildingHologram() : Super() {
 	this->mBuildModeZoop = nullptr;
 	this->mBuildModeCategory = EHologramBuildModeCategory::HBMC_Architecture;
 }
-void AFGFactoryBuildingHologram::BeginPlay(){ }
+void AFGFactoryBuildingHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGFactoryBuildingHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGFactoryBuildingHologram, mDesiredZoop);

--- a/Source/FactoryGame/Private/Hologram/FGFactoryHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGFactoryHologram.cpp
@@ -5,6 +5,6 @@
 AFGFactoryHologram::AFGFactoryHologram() : Super() {
 
 }
-void AFGFactoryHologram::BeginPlay(){ }
-void AFGFactoryHologram::Tick(float dt){ }
+void AFGFactoryHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGFactoryHologram::Tick(float dt){ Super::Tick(dt); }
 void AFGFactoryHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }

--- a/Source/FactoryGame/Private/Hologram/FGFloodlightHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGFloodlightHologram.cpp
@@ -12,7 +12,7 @@ void AFGFloodlightHologram::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGFloodlightHologram, mFixtureAngle);
 }
-void AFGFloodlightHologram::BeginPlay(){ }
+void AFGFloodlightHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGFloodlightHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGFloodlightHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 void AFGFloodlightHologram::ScrollRotate(int32 delta, int32 step){ }

--- a/Source/FactoryGame/Private/Hologram/FGFoundationHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGFoundationHologram.cpp
@@ -11,7 +11,7 @@ AFGFoundationHologram::AFGFoundationHologram() : Super() {
 	this->mMaxPlacementFloorAngle = 85.0;
 	this->mAllowEdgePlacementInDesignerEvenOnIntersect = true;
 }
-void AFGFoundationHologram::BeginPlay(){ }
+void AFGFoundationHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGFoundationHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 bool AFGFoundationHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGFoundationHologram::GetSupportedBuildModes_Implementation(TArray<TSubclassOf<UFGBuildGunModeDescriptor>>& out_buildmodes) const{ }

--- a/Source/FactoryGame/Private/Hologram/FGGenericBuildableHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGGenericBuildableHologram.cpp
@@ -16,7 +16,7 @@ AFGGenericBuildableHologram::AFGGenericBuildableHologram() : Super() {
 	this->mSnapAxis = EAxis::Z;
 	this->mFoundationSnappingInset = 0.0;
 }
-void AFGGenericBuildableHologram::BeginPlay(){ }
+void AFGGenericBuildableHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGGenericBuildableHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 int32 AFGGenericBuildableHologram::GetRotationStep() const{ return int32(); }
 ENudgeFailReason AFGGenericBuildableHologram::NudgeHologram(const FVector& NudgeInput, const FHitResult& HitResult){ return ENudgeFailReason(); }

--- a/Source/FactoryGame/Private/Hologram/FGGeoThermalGeneratorHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGGeoThermalGeneratorHologram.cpp
@@ -2,6 +2,6 @@
 
 #include "Hologram/FGGeoThermalGeneratorHologram.h"
 
-void AFGGeoThermalGeneratorHologram::BeginPlay(){ }
+void AFGGeoThermalGeneratorHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGGeoThermalGeneratorHologram::ConfigureActor( AFGBuildable* inBuildable) const{ }
 bool AFGGeoThermalGeneratorHologram::CanOccupyResource(const TScriptInterface<  IFGExtractableResourceInterface >& resource) const{ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGHologram.cpp
@@ -55,8 +55,8 @@ TSubclassOf< class UFGItemDescriptor > AFGHologram::GetItemDescriptor() const{ r
 void AFGHologram::SerializeConstructMessage(FArchive& ar, FNetConstructionID id){ }
 void AFGHologram::PreConstructMessageSerialization(){ }
 void AFGHologram::PostConstructMessageDeserialization(){ }
-void AFGHologram::BeginPlay(){ }
-void AFGHologram::Destroyed(){ }
+void AFGHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGHologram::Destroyed(){ Super::Destroyed(); }
 void AFGHologram::SetActorHiddenInGame(bool newHidden){ }
 void AFGHologram::OnNearbyBuildableOverlapBegin( AFGBuildable* buildable){ }
 void AFGHologram::OnNearbyBuildableOverlapEnd( AFGBuildable* buildable){ }

--- a/Source/FactoryGame/Private/Hologram/FGJumpPadHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGJumpPadHologram.cpp
@@ -12,8 +12,8 @@ AFGJumpPadHologram::AFGJumpPadHologram() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGJumpPadHologram::BeginPlay(){ }
-void AFGJumpPadHologram::EndPlay(const EEndPlayReason::Type endPlayReason){ }
-void AFGJumpPadHologram::Tick(float dt){ }
+void AFGJumpPadHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGJumpPadHologram::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGJumpPadHologram::Tick(float dt){ Super::Tick(dt); }
 void AFGJumpPadHologram::DisplayNearbyJumpPadTrajectories(){ }
 void AFGJumpPadHologram::OnTraceCompleted(const FTraceHandle& Handle, FOverlapDatum& Data){ }

--- a/Source/FactoryGame/Private/Hologram/FGJumpPadLauncherHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGJumpPadLauncherHologram.cpp
@@ -25,7 +25,7 @@ void AFGJumpPadLauncherHologram::GetLifetimeReplicatedProps(TArray<FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGJumpPadLauncherHologram, mLaunchAngle);
 }
-void AFGJumpPadLauncherHologram::BeginPlay(){ }
+void AFGJumpPadLauncherHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGJumpPadLauncherHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGJumpPadLauncherHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 void AFGJumpPadLauncherHologram::ScrollRotate(int32 delta, int32 step){ }

--- a/Source/FactoryGame/Private/Hologram/FGLadderHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGLadderHologram.cpp
@@ -21,7 +21,7 @@ void AFGLadderHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& 
 	DOREPLIFETIME(AFGLadderHologram, mTargetSegmentHeight);
 	DOREPLIFETIME(AFGLadderHologram, mBuildStep);
 }
-void AFGLadderHologram::BeginPlay(){ }
+void AFGLadderHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGLadderHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 void AFGLadderHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 bool AFGLadderHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGPassthroughHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPassthroughHologram.cpp
@@ -8,7 +8,7 @@ AFGPassthroughHologram::AFGPassthroughHologram() : Super() {
 	this->mAllowMultiFoundationPassThrough = false;
 	this->mSnappedBuildingThickness = 0.0;
 }
-void AFGPassthroughHologram::BeginPlay(){ }
+void AFGPassthroughHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPassthroughHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPassthroughHologram, mSnappedBuildingThickness);

--- a/Source/FactoryGame/Private/Hologram/FGPillarHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPillarHologram.cpp
@@ -14,7 +14,7 @@ AFGPillarHologram::AFGPillarHologram() : Super() {
 	this->mAllowEdgePlacementInDesignerEvenOnIntersect = true;
 	this->mInstancedMeshComponent->SetupAttachment(RootComponent);
 }
-void AFGPillarHologram::BeginPlay(){ }
+void AFGPillarHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPillarHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPillarHologram, mCurrentZoop);

--- a/Source/FactoryGame/Private/Hologram/FGPipeAttachmentHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipeAttachmentHologram.cpp
@@ -25,7 +25,7 @@ void AFGPipeAttachmentHologram::GetLifetimeReplicatedProps(TArray<FLifetimePrope
 	DOREPLIFETIME(AFGPipeAttachmentHologram, mSnappedConnectionComponent);
 	DOREPLIFETIME(AFGPipeAttachmentHologram, mSnappedPipeOffset);
 }
-void AFGPipeAttachmentHologram::BeginPlay(){ }
+void AFGPipeAttachmentHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGPipeAttachmentHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGPipeAttachmentHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }
 void AFGPipeAttachmentHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }

--- a/Source/FactoryGame/Private/Hologram/FGPipeHyperAttachmentHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipeHyperAttachmentHologram.cpp
@@ -10,6 +10,6 @@ AFGPipeHyperAttachmentHologram::AFGPipeHyperAttachmentHologram() : Super() {
 	this->mBasePipeClass = AFGBuildablePipeHyper::StaticClass();
 	this->mPipeAttachmentInterfaceClass = UFGPipeHyperAttachmentSnapTargetInterface::StaticClass();
 }
-void AFGPipeHyperAttachmentHologram::BeginPlay(){ }
+void AFGPipeHyperAttachmentHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPipeHyperAttachmentHologram::ConfigureComponents(AFGBuildable* inBuildable) const{ }
 void AFGPipeHyperAttachmentHologram::CheckValidPlacement(){ }

--- a/Source/FactoryGame/Private/Hologram/FGPipePartHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipePartHologram.cpp
@@ -11,7 +11,7 @@ AFGPipePartHologram::AFGPipePartHologram() : Super() {
 	this->mSupportMeshComponent = nullptr;
 	this->mSupportLengthComponent = nullptr;
 }
-void AFGPipePartHologram::BeginPlay(){ }
+void AFGPipePartHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPipePartHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPipePartHologram, mSupportMesh);

--- a/Source/FactoryGame/Private/Hologram/FGPipeReservoirHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipeReservoirHologram.cpp
@@ -5,7 +5,7 @@
 AFGPipeReservoirHologram::AFGPipeReservoirHologram() : Super() {
 
 }
-void AFGPipeReservoirHologram::BeginPlay(){ }
+void AFGPipeReservoirHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGPipeReservoirHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGPipeReservoirHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 int32 AFGPipeReservoirHologram::GetRotationStep() const{ return int32(); }

--- a/Source/FactoryGame/Private/Hologram/FGPipelineAttachmentHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipelineAttachmentHologram.cpp
@@ -10,5 +10,5 @@ AFGPipelineAttachmentHologram::AFGPipelineAttachmentHologram() : Super() {
 	this->mBasePipeClass = AFGBuildablePipeline::StaticClass();
 	this->mPipeAttachmentInterfaceClass = UFGPipeAttachmentSnapTargetInterface::StaticClass();
 }
-void AFGPipelineAttachmentHologram::BeginPlay(){ }
+void AFGPipelineAttachmentHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPipelineAttachmentHologram::ConfigureComponents(AFGBuildable* inBuildable) const{ }

--- a/Source/FactoryGame/Private/Hologram/FGPipelineHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipelineHologram.cpp
@@ -33,7 +33,7 @@ AFGPipelineHologram::AFGPipelineHologram() : Super() {
 	this->mBuildModeCategory = EHologramBuildModeCategory::HBMC_Pipe;
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGPipelineHologram::BeginPlay(){ }
+void AFGPipelineHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPipelineHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPipelineHologram, mChildPoleHologram);

--- a/Source/FactoryGame/Private/Hologram/FGPipelinePumpHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipelinePumpHologram.cpp
@@ -22,7 +22,7 @@ AFGPipelinePumpHologram::AFGPipelinePumpHologram() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGPipelinePumpHologram::Tick(float dt){ }
+void AFGPipelinePumpHologram::Tick(float dt){ Super::Tick(dt); }
 bool AFGPipelinePumpHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 float AFGPipelinePumpHologram::GetHeadLiftPathLength(const FPumpHeadLiftLocationPath& Path){ return float(); }
 TArray<FTransform> AFGPipelinePumpHologram::GetTransformsAtDistanceAlongPath(const FPumpHeadLiftLocationPath& Path, float Distance){ return TArray<FTransform>(); }

--- a/Source/FactoryGame/Private/Hologram/FGPipelineSupportHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPipelineSupportHologram.cpp
@@ -23,7 +23,7 @@ AFGPipelineSupportHologram::AFGPipelineSupportHologram() : Super() {
 	this->mAllowEdgePlacementInDesignerEvenOnIntersect = true;
 	this->mInstancedMeshComponent->SetupAttachment(RootComponent);
 }
-void AFGPipelineSupportHologram::BeginPlay(){ }
+void AFGPipelineSupportHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPipelineSupportHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPipelineSupportHologram, mVerticalAngle);

--- a/Source/FactoryGame/Private/Hologram/FGPoleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPoleHologram.cpp
@@ -25,7 +25,7 @@ void AFGPoleHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& Ou
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPoleHologram, mPoleHeight);
 }
-void AFGPoleHologram::BeginPlay(){ }
+void AFGPoleHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGPoleHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }
 bool AFGPoleHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGPoleHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGPowerPoleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPowerPoleHologram.cpp
@@ -3,8 +3,8 @@
 #include "Hologram/FGPowerPoleHologram.h"
 #include "Net/UnrealNetwork.h"
 
-void AFGPowerPoleHologram::BeginPlay(){ }
-void AFGPowerPoleHologram::Destroyed(){ }
+void AFGPowerPoleHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGPowerPoleHologram::Destroyed(){ Super::Destroyed(); }
 void AFGPowerPoleHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPowerPoleHologram, mSnapWire);

--- a/Source/FactoryGame/Private/Hologram/FGPowerPoleWallHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGPowerPoleWallHologram.cpp
@@ -13,7 +13,7 @@ AFGPowerPoleWallHologram::AFGPowerPoleWallHologram() : Super() {
 	this->mWireHologramOut = nullptr;
 	this->mDefaultPowerLineRecipe = nullptr;
 }
-void AFGPowerPoleWallHologram::BeginPlay(){ }
+void AFGPowerPoleWallHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGPowerPoleWallHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGPowerPoleWallHologram, mUpgradeTarget);
@@ -21,7 +21,7 @@ void AFGPowerPoleWallHologram::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	DOREPLIFETIME(AFGPowerPoleWallHologram, mWireHologramIn);
 	DOREPLIFETIME(AFGPowerPoleWallHologram, mWireHologramOut);
 }
-void AFGPowerPoleWallHologram::Destroyed(){ }
+void AFGPowerPoleWallHologram::Destroyed(){ Super::Destroyed(); }
 USceneComponent* AFGPowerPoleWallHologram::SetupComponent(USceneComponent* attachParent, UActorComponent* componentTemplate, const FName& componentName, const FName& attachSocketName){ return nullptr; }
 AActor* AFGPowerPoleWallHologram::Construct(TArray< AActor* >& out_children, FNetConstructionID constructionID){ return nullptr; }
 void AFGPowerPoleWallHologram::SpawnChildren(AActor* hologramOwner, FVector spawnLocation, APawn* hologramInstigator){ }

--- a/Source/FactoryGame/Private/Hologram/FGRailroadSignalHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRailroadSignalHologram.cpp
@@ -8,8 +8,8 @@ AFGRailroadSignalHologram::AFGRailroadSignalHologram() : Super() {
 	this->mSnappedRailroadTrack = nullptr;
 	this->mUpgradeTarget = nullptr;
 }
-void AFGRailroadSignalHologram::BeginPlay(){ }
-void AFGRailroadSignalHologram::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGRailroadSignalHologram::BeginPlay(){ Super::BeginPlay(); }
+void AFGRailroadSignalHologram::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGRailroadSignalHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGRailroadSignalHologram, mSnappedConnection);

--- a/Source/FactoryGame/Private/Hologram/FGRailroadTrackHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRailroadTrackHologram.cpp
@@ -22,7 +22,7 @@ void AFGRailroadTrackHologram::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGRailroadTrackHologram, mSwitchControls);
 }
-void AFGRailroadTrackHologram::BeginPlay(){ }
+void AFGRailroadTrackHologram::BeginPlay(){ Super::BeginPlay(); }
 USceneComponent* AFGRailroadTrackHologram::SetupComponent(USceneComponent* attachParent, UActorComponent* componentTemplate, const FName& componentName, const FName& attachSocketName){ return nullptr; }
 void AFGRailroadTrackHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 int32 AFGRailroadTrackHologram::GetBaseCostMultiplier() const{ return int32(); }

--- a/Source/FactoryGame/Private/Hologram/FGRailroadVehicleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRailroadVehicleHologram.cpp
@@ -3,7 +3,7 @@
 #include "Hologram/FGRailroadVehicleHologram.h"
 #include "Net/UnrealNetwork.h"
 
-void AFGRailroadVehicleHologram::BeginPlay(){ }
+void AFGRailroadVehicleHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGRailroadVehicleHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGRailroadVehicleHologram, mTrackPosition);

--- a/Source/FactoryGame/Private/Hologram/FGRailroadVehicleRerailHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRailroadVehicleRerailHologram.cpp
@@ -13,7 +13,7 @@ AFGRailroadVehicleRerailHologram::AFGRailroadVehicleRerailHologram() : Super() {
 	this->PrimaryActorTick.TickInterval = 1.0;
 	this->RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("RootComponent"));
 }
-void AFGRailroadVehicleRerailHologram::Tick(float dt){ }
+void AFGRailroadVehicleRerailHologram::Tick(float dt){ Super::Tick(dt); }
 void AFGRailroadVehicleRerailHologram::PreSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGRailroadVehicleRerailHologram::PostSaveGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 void AFGRailroadVehicleRerailHologram::PreLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }

--- a/Source/FactoryGame/Private/Hologram/FGRampHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRampHologram.cpp
@@ -5,7 +5,7 @@
 AFGRampHologram::AFGRampHologram() : Super() {
 
 }
-void AFGRampHologram::BeginPlay(){ }
+void AFGRampHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGRampHologram::IsHologramIdenticalToActor(AActor* actor, const FVector& hologramLocationOffset) const{ return bool(); }
 void AFGRampHologram::UpdateZoop(){ }
 void AFGRampHologram::ConstructZoop(TArray<AActor*>& out_children){ }

--- a/Source/FactoryGame/Private/Hologram/FGResourceExtractorHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGResourceExtractorHologram.cpp
@@ -10,7 +10,7 @@ AFGResourceExtractorHologram::AFGResourceExtractorHologram() : Super() {
 	this->mNeedsValidFloor = false;
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGResourceExtractorHologram::BeginPlay(){ }
+void AFGResourceExtractorHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGResourceExtractorHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGResourceExtractorHologram, mSnappedExtractableResource);

--- a/Source/FactoryGame/Private/Hologram/FGRoadHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGRoadHologram.cpp
@@ -8,7 +8,7 @@ AFGRoadHologram::AFGRoadHologram() : Super() {
 	this->mSnappedConnectionComponents[0] = nullptr;
 	this->mSnappedConnectionComponents[1] = nullptr;
 }
-void AFGRoadHologram::BeginPlay(){ }
+void AFGRoadHologram::BeginPlay(){ Super::BeginPlay(); }
 USceneComponent* AFGRoadHologram::SetupComponent(USceneComponent* attachParent, UActorComponent* componentTemplate, const FName& componentName, const FName& attachSocketName){ return nullptr; }
 void AFGRoadHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 bool AFGRoadHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }

--- a/Source/FactoryGame/Private/Hologram/FGSignPoleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGSignPoleHologram.cpp
@@ -5,6 +5,6 @@
 AFGSignPoleHologram::AFGSignPoleHologram() : Super() {
 	this->mUseBuildClearanceOverlapSnapp = false;
 }
-void AFGSignPoleHologram::BeginPlay(){ }
+void AFGSignPoleHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGSignPoleHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGSignPoleHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }

--- a/Source/FactoryGame/Private/Hologram/FGSplineHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGSplineHologram.cpp
@@ -23,7 +23,7 @@ void AFGSplineHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& 
 	DOREPLIFETIME(AFGSplineHologram, mSplineData);
 	DOREPLIFETIME(AFGSplineHologram, mBuildStep);
 }
-void AFGSplineHologram::BeginPlay(){ }
+void AFGSplineHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGSplineHologram::CanNudgeHologram() const{ return bool(); }
 bool AFGSplineHologram::IsConnectionSnapped(bool lastConnection){ return bool(); }
 void AFGSplineHologram::GetLastSplineData(FSplinePointData& data){ }

--- a/Source/FactoryGame/Private/Hologram/FGStackableStorageHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGStackableStorageHologram.cpp
@@ -5,7 +5,7 @@
 AFGStackableStorageHologram::AFGStackableStorageHologram() : Super() {
 
 }
-void AFGStackableStorageHologram::BeginPlay(){ }
+void AFGStackableStorageHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGStackableStorageHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGStackableStorageHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 int32 AFGStackableStorageHologram::GetRotationStep() const{ return int32(); }

--- a/Source/FactoryGame/Private/Hologram/FGStairHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGStairHologram.cpp
@@ -5,7 +5,7 @@
 AFGStairHologram::AFGStairHologram() : Super() {
 
 }
-void AFGStairHologram::BeginPlay(){ }
+void AFGStairHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGStairHologram::TrySnapToActor(const FHitResult& hitResult){ return bool(); }
 void AFGStairHologram::AdjustForGround(FVector& out_adjustedLocation, FRotator& out_adjustedRotation){ }
 void AFGStairHologram::CheckValidPlacement(){ }

--- a/Source/FactoryGame/Private/Hologram/FGStandaloneSignHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGStandaloneSignHologram.cpp
@@ -16,7 +16,7 @@ void AFGStandaloneSignHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProp
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGStandaloneSignHologram, mChildSignPoleHologram);
 }
-void AFGStandaloneSignHologram::BeginPlay(){ }
+void AFGStandaloneSignHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGStandaloneSignHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 bool AFGStandaloneSignHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }
 void AFGStandaloneSignHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }

--- a/Source/FactoryGame/Private/Hologram/FGTrainPlatformHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGTrainPlatformHologram.cpp
@@ -16,7 +16,7 @@ void AFGTrainPlatformHologram::GetLifetimeReplicatedProps(TArray< FLifetimePrope
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGTrainPlatformHologram, mRailroadTrackHologram);
 }
-void AFGTrainPlatformHologram::BeginPlay(){ }
+void AFGTrainPlatformHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGTrainPlatformHologram::SpawnChildren(AActor* hologramOwner, FVector spawnLocation, APawn* hologramInstigator){ }
 AActor* AFGTrainPlatformHologram::Construct(TArray< AActor* >& out_children, FNetConstructionID netConstructionID){ return nullptr; }
 void AFGTrainPlatformHologram::GetIgnoredClearanceActors(TArray< AActor* >& ignoredActors) const{ }

--- a/Source/FactoryGame/Private/Hologram/FGVehicleHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGVehicleHologram.cpp
@@ -9,7 +9,7 @@ void AFGVehicleHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >&
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 }
-void AFGVehicleHologram::BeginPlay(){ }
+void AFGVehicleHologram::BeginPlay(){ Super::BeginPlay(); }
 AActor* AFGVehicleHologram::Construct(TArray< AActor* >& out_children, FNetConstructionID netConstructionID){ return nullptr; }
 void AFGVehicleHologram::SetHologramLocationAndRotation(const FHitResult& hitResult){ }
 void AFGVehicleHologram::CheckValidPlacement(){ }

--- a/Source/FactoryGame/Private/Hologram/FGWalkwayHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGWalkwayHologram.cpp
@@ -13,4 +13,4 @@ void AFGWalkwayHologram::CheckValidPlacement(){ }
 void AFGWalkwayHologram::UpdateZoop(){ }
 void AFGWalkwayHologram::ConstructZoop(TArray<AActor*>& out_children){ }
 FVector AFGWalkwayHologram::ConvertZoopToWorldLocation(const FIntVector& zoop) const{ return FVector(); }
-void AFGWalkwayHologram::BeginPlay(){ }
+void AFGWalkwayHologram::BeginPlay(){ Super::BeginPlay(); }

--- a/Source/FactoryGame/Private/Hologram/FGWallHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGWallHologram.cpp
@@ -9,7 +9,7 @@ AFGWallHologram::AFGWallHologram() : Super() {
 	this->mPlacementRequirements = EFactoryBuildingPlacementRequirements::FBPR_MustSnap;
 	this->mAllowEdgePlacementInDesignerEvenOnIntersect = true;
 }
-void AFGWallHologram::BeginPlay(){ }
+void AFGWallHologram::BeginPlay(){ Super::BeginPlay(); }
 void AFGWallHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(AFGWallHologram, mUpgradeTarget);

--- a/Source/FactoryGame/Private/Hologram/FGWaterPumpHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGWaterPumpHologram.cpp
@@ -5,7 +5,7 @@
 AFGWaterPumpHologram::AFGWaterPumpHologram() : Super() {
 	this->mDefaultWaterPump = nullptr;
 }
-void AFGWaterPumpHologram::BeginPlay(){ }
+void AFGWaterPumpHologram::BeginPlay(){ Super::BeginPlay(); }
 bool AFGWaterPumpHologram::IsValidHitResult(const FHitResult& hitResult) const{ return bool(); }
 void AFGWaterPumpHologram::CheckValidPlacement(){ }
 void AFGWaterPumpHologram::PostHologramPlacement(const FHitResult& hitResult){ }

--- a/Source/FactoryGame/Private/Hologram/FGWireHologram.cpp
+++ b/Source/FactoryGame/Private/Hologram/FGWireHologram.cpp
@@ -26,7 +26,7 @@ void AFGWireHologram::GetLifetimeReplicatedProps(TArray< FLifetimeProperty >& Ou
 	DOREPLIFETIME(AFGWireHologram, mStartLocation);
 	DOREPLIFETIME(AFGWireHologram, mCurrentConnection);
 }
-void AFGWireHologram::BeginPlay(){ }
+void AFGWireHologram::BeginPlay(){ Super::BeginPlay(); }
 AActor* AFGWireHologram::Construct(TArray< AActor* >& out_children, FNetConstructionID netConstructionID){ return nullptr; }
 int32 AFGWireHologram::GetBaseCostMultiplier() const{ return int32(); }
 bool AFGWireHologram::DoMultiStepPlacement(bool isInputFromARelease){ return bool(); }
@@ -46,7 +46,7 @@ bool AFGWireHologram::ShouldActorBeConsideredForGuidelines( AActor* actor) const
 void AFGWireHologram::SetConnection(int32 ix, UFGCircuitConnectionComponent* connection){ }
 UFGCircuitConnectionComponent* AFGWireHologram::GetConnection(int32 ix) const{ return nullptr; }
 bool AFGWireHologram::IsPowerTowerWire() const{ return bool(); }
-void AFGWireHologram::Destroyed(){ }
+void AFGWireHologram::Destroyed(){ Super::Destroyed(); }
 void AFGWireHologram::CheckValidPlacement(){ }
 void AFGWireHologram::CheckClearance(const FVector& locationOffset){ }
 uint8 AFGWireHologram::GetStencilForHologramMaterialState(EHologramMaterialState state) const{ return uint8(); }

--- a/Source/FactoryGame/Private/QAPickableItem.cpp
+++ b/Source/FactoryGame/Private/QAPickableItem.cpp
@@ -11,5 +11,5 @@ AQAPickableItem::AQAPickableItem() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AQAPickableItem::BeginPlay(){ }
-void AQAPickableItem::Tick(float DeltaTime){ }
+void AQAPickableItem::BeginPlay(){ Super::BeginPlay(); }
+void AQAPickableItem::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/Resources/FGResourceDeposit.cpp
+++ b/Source/FactoryGame/Private/Resources/FGResourceDeposit.cpp
@@ -24,7 +24,7 @@ void AFGResourceDeposit::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& O
 	DOREPLIFETIME(AFGResourceDeposit, mMineAmount);
 }
 void AFGResourceDeposit::PostLoad(){ Super::PostLoad(); }
-void AFGResourceDeposit::BeginPlay(){ }
+void AFGResourceDeposit::BeginPlay(){ Super::BeginPlay(); }
 void AFGResourceDeposit::RollResourceType(){ }
 void AFGResourceDeposit::TrySetDesiredResourceType(){ }
 void AFGResourceDeposit::SetupResourceInfo(){ }

--- a/Source/FactoryGame/Private/Resources/FGResourceNode.cpp
+++ b/Source/FactoryGame/Private/Resources/FGResourceNode.cpp
@@ -18,7 +18,7 @@ AFGResourceNode::AFGResourceNode() : Super() {
 	this->mCanPlaceResourceExtractor = true;
 	this->mExtractMultiplier = 1;
 }
-void AFGResourceNode::BeginPlay(){ }
+void AFGResourceNode::BeginPlay(){ Super::BeginPlay(); }
 void AFGResourceNode::UpdateUseState_Implementation( AFGCharacterPlayer* byCharacter, const FVector& atLocation,  UPrimitiveComponent* componentHit, FUseState& out_useState){ }
 void AFGResourceNode::OnUse_Implementation( AFGCharacterPlayer* byCharacter, const FUseState& state){ }
 void AFGResourceNode::OnUseStop_Implementation( AFGCharacterPlayer* byCharacter, const FUseState& state){ }

--- a/Source/FactoryGame/Private/Resources/FGResourceNodeBase.cpp
+++ b/Source/FactoryGame/Private/Resources/FGResourceNodeBase.cpp
@@ -33,8 +33,8 @@ void AFGResourceNodeBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 	DOREPLIFETIME(AFGResourceNodeBase, mDoSpawnParticle);
 }
 void AFGResourceNodeBase::PostLoad(){ Super::PostLoad(); }
-void AFGResourceNodeBase::BeginPlay(){ }
-void AFGResourceNodeBase::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGResourceNodeBase::BeginPlay(){ Super::BeginPlay(); }
+void AFGResourceNodeBase::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGResourceNodeBase::GainedSignificance_Implementation(){ }
 void AFGResourceNodeBase::LostSignificance_Implementation(){ }
 void AFGResourceNodeBase::GainedSignificance_Native(){ }

--- a/Source/FactoryGame/Private/Resources/FGResourceNodeFrackingCore.cpp
+++ b/Source/FactoryGame/Private/Resources/FGResourceNodeFrackingCore.cpp
@@ -5,8 +5,8 @@
 AFGResourceNodeFrackingCore::AFGResourceNodeFrackingCore() : Super() {
 
 }
-void AFGResourceNodeFrackingCore::BeginPlay(){ }
-void AFGResourceNodeFrackingCore::EndPlay(const EEndPlayReason::Type endPlayReason){ }
+void AFGResourceNodeFrackingCore::BeginPlay(){ Super::BeginPlay(); }
+void AFGResourceNodeFrackingCore::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGResourceNodeFrackingCore::RegisterSatellite(TWeakObjectPtr<  AFGResourceNodeFrackingSatellite > satellite){ }
 void AFGResourceNodeFrackingCore::Factory_SetSatellitesActive(bool isActive){ }
 void AFGResourceNodeFrackingCore::GetSatellites(TArray<  AFGResourceNodeFrackingSatellite* >& out_Satellites) const{ }

--- a/Source/FactoryGame/Private/Resources/FGResourceNodeFrackingSatellite.cpp
+++ b/Source/FactoryGame/Private/Resources/FGResourceNodeFrackingSatellite.cpp
@@ -14,7 +14,7 @@ void AFGResourceNodeFrackingSatellite::GetLifetimeReplicatedProps(TArray<FLifeti
 	DOREPLIFETIME(AFGResourceNodeFrackingSatellite, mState);
 }
 void AFGResourceNodeFrackingSatellite::OnConstruction(const FTransform& Transform){ }
-void AFGResourceNodeFrackingSatellite::BeginPlay(){ }
+void AFGResourceNodeFrackingSatellite::BeginPlay(){ Super::BeginPlay(); }
 void AFGResourceNodeFrackingSatellite::SetIsOccupied(bool occupied){ }
 bool AFGResourceNodeFrackingSatellite::CanPlaceResourceExtractor() const{ return bool(); }
 void AFGResourceNodeFrackingSatellite::OnRep_IsOccupied(){ }

--- a/Source/FactoryGame/Private/ShoppingList/FGShoppingListComponent.cpp
+++ b/Source/FactoryGame/Private/ShoppingList/FGShoppingListComponent.cpp
@@ -21,7 +21,7 @@ void UFGShoppingListComponent::OnBlueprintRemoved(const FString& blueprintName){
 void UFGShoppingListComponent::UpdateShoppingListObjectBlueprint( UFGShoppingListObject_Object* shoppingListObject_Object){ }
 void UFGShoppingListComponent::UpdateShoppingListObjectClass( UFGShoppingListObject_Class* shoppingListObject_Class){ }
 void UFGShoppingListComponent::UpdateShoppingList(){ }
-void UFGShoppingListComponent::BeginPlay(){ }
+void UFGShoppingListComponent::BeginPlay(){ Super::BeginPlay(); }
 void UFGShoppingListComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 	DOREPLIFETIME(UFGShoppingListComponent, mShoppingListBlueprints);

--- a/Source/FactoryGame/Private/Tests/FGProfileSpline.cpp
+++ b/Source/FactoryGame/Private/Tests/FGProfileSpline.cpp
@@ -12,5 +12,5 @@ AFGProfileSpline::AFGProfileSpline() : Super() {
 	this->PrimaryActorTick.bAllowTickOnDedicatedServer = true;
 	this->PrimaryActorTick.TickInterval = 0.0;
 }
-void AFGProfileSpline::BeginPlay(){ }
-void AFGProfileSpline::Tick(float DeltaTime){ }
+void AFGProfileSpline::BeginPlay(){ Super::BeginPlay(); }
+void AFGProfileSpline::Tick(float DeltaTime){ Super::Tick(DeltaTime); }

--- a/Source/FactoryGame/Private/Tests/FGTestManager.cpp
+++ b/Source/FactoryGame/Private/Tests/FGTestManager.cpp
@@ -36,8 +36,8 @@ bool AFGTestManager::ShouldSave_Implementation() const{ return bool(); }
 AFGTestManager* AFGTestManager::Get(const UObject* worldContext){ return nullptr; }
 bool AFGTestManager::ShouldSpawnForWorld(const UWorld* world){ return bool(); }
 FString AFGTestManager::GetWorldGameplayTestName(const UWorld* world){ return FString(); }
-void AFGTestManager::BeginPlay(){ }
-void AFGTestManager::Tick(float DeltaSeconds){ }
+void AFGTestManager::BeginPlay(){ Super::BeginPlay(); }
+void AFGTestManager::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 void AFGTestManager::DisplayDebug(UCanvas* Canvas, const FDebugDisplayInfo& DebugDisplay, float& YL, float& YPos){ }
 UFGGameplayTest* AFGTestManager::RunGameplayTest(TSubclassOf<UFGGameplayTest> gameplayTest){ return nullptr; }
 void AFGTestManager::GetRunningGameplayTests(TArray<UFGGameplayTest*>& out_gameplayTests) const{ }

--- a/Source/FactoryGame/Private/UI/FGBaseUI.cpp
+++ b/Source/FactoryGame/Private/UI/FGBaseUI.cpp
@@ -5,8 +5,8 @@
 UFGBaseUI::UFGBaseUI(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer) {
 	this->mActivePopup = nullptr;
 }
-void UFGBaseUI::NativeConstruct(){ }
-void UFGBaseUI::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ }
+void UFGBaseUI::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGBaseUI::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ Super::NativeTick(MyGeometry, InDeltaTime); }
 void UFGBaseUI::AddPopupToQueue(FPopupData inPopupData){ }
 void UFGBaseUI::AddPopup(FText Title, FText Body, const FPopupConfirmClicked& ConfirmClickDelegate, EPopupId PopupID , TSubclassOf< UUserWidget > popupClass){ }
 void UFGBaseUI::PopPopupQueue(){ }

--- a/Source/FactoryGame/Private/UI/FGButtonHintBar.cpp
+++ b/Source/FactoryGame/Private/UI/FGButtonHintBar.cpp
@@ -2,7 +2,7 @@
 
 #include "UI/FGButtonHintBar.h"
 
-void UFGButtonHintBar::NativeConstruct(){ }
+void UFGButtonHintBar::NativeConstruct(){ Super::NativeConstruct(); }
 void UFGButtonHintBar::UpdateButtonHints(const TArray<FFGButtonHintDescription>& buttonHints){ }
 void UFGButtonHintBar::UpdateKeyHintsFromWidgetPath(){ }
 void UFGButtonHintBar::HandleSlateFocusChanging(const FFocusEvent& FocusEvent, const FWeakWidgetPath& OldFocusedWidgetPath, const TSharedPtr<SWidget>& OldFocusedWidget, const FWidgetPath& NewFocusedWidgetPath, const TSharedPtr<SWidget>& NewFocusedWidget){ }

--- a/Source/FactoryGame/Private/UI/FGControllerDragWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGControllerDragWidget.cpp
@@ -2,6 +2,6 @@
 
 #include "UI/FGControllerDragWidget.h"
 
-void UFGControllerDragWidget::NativeConstruct(){ }
-void UFGControllerDragWidget::NativeDestruct(){ }
+void UFGControllerDragWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGControllerDragWidget::NativeDestruct(){ Super::NativeDestruct(); }
 void UFGControllerDragWidget::HandleSlateFocusChanging(const FFocusEvent& FocusEvent, const FWeakWidgetPath& OldFocusedWidgetPath, const TSharedPtr<SWidget>& OldFocusedWidget, const FWidgetPath& NewFocusedWidgetPath, const TSharedPtr<SWidget>& NewFocusedWidget){ }

--- a/Source/FactoryGame/Private/UI/FGDynamicOptionsRow.cpp
+++ b/Source/FactoryGame/Private/UI/FGDynamicOptionsRow.cpp
@@ -2,7 +2,7 @@
 
 #include "UI/FGDynamicOptionsRow.h"
 
-void UFGDynamicOptionsRow::NativePreConstruct(){ }
+void UFGDynamicOptionsRow::NativePreConstruct(){ Super::NativePreConstruct(); }
 void UFGDynamicOptionsRow::InitOptionRow(FOptionRowData optionRowData, TSubclassOf<class UFGOptionsValueController> widgetOptionClass, TScriptInterface<  IFGOptionInterface > optionInterface){ }
 void UFGDynamicOptionsRow::InitOptionRow( UFGUserSetting* userSetting, TScriptInterface<  IFGOptionInterface > optionInterface){ }
 void UFGDynamicOptionsRow::AddSubOption(UFGDynamicOptionsRow* dynamicOptionsRow){ }

--- a/Source/FactoryGame/Private/UI/FGGameUI.cpp
+++ b/Source/FactoryGame/Private/UI/FGGameUI.cpp
@@ -7,10 +7,10 @@ UFGGameUI::UFGGameUI(const FObjectInitializer& ObjectInitializer) : Super(Object
 	this->mActiveAudioMessage = nullptr;
 	this->mControllerDragWidget = nullptr;
 }
-void UFGGameUI::NativeConstruct(){ }
+void UFGGameUI::NativeConstruct(){ Super::NativeConstruct(); }
 void UFGGameUI::ReleaseSlateResources(bool bReleaseChildren){ Super::ReleaseSlateResources(bReleaseChildren); }
 void UFGGameUI::PopAllWidgets_Implementation(){ }
-void UFGGameUI::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ }
+void UFGGameUI::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ Super::NativeTick(MyGeometry, InDeltaTime); }
 UFGInteractWidget* UFGGameUI::GetInteractWidgetOfClass(TSubclassOf< UFGInteractWidget > interactWidgetClass) const{ return nullptr; }
 void UFGGameUI::GetInteractWidgetsOfInteractObject(const UObject* InteractObject, TArray<UFGInteractWidget*>& OutInteractWidgets) const{ }
 bool UFGGameUI::ContainsInteractWidgetOfClass(TSubclassOf< UFGInteractWidget > interactWidgetClass) const{ return bool(); }

--- a/Source/FactoryGame/Private/UI/FGGridNavigationHelper.cpp
+++ b/Source/FactoryGame/Private/UI/FGGridNavigationHelper.cpp
@@ -2,7 +2,7 @@
 
 #include "UI/FGGridNavigationHelper.h"
 
-void UFGGridNavigationHelper::NativeConstruct(){ }
+void UFGGridNavigationHelper::NativeConstruct(){ Super::NativeConstruct(); }
 void UFGGridNavigationHelper::SetupNavigation(const TArray<UWidget*>& widgets){ }
 UWidget* UFGGridNavigationHelper::DoNavigation(EUINavigation NavigationDirection){ return nullptr; }
 UWidget* UFGGridNavigationHelper::FindNextGridWidget(UWidget* Pivot, EUINavigation NavigationDirection){ return nullptr; }

--- a/Source/FactoryGame/Private/UI/FGInteractWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGInteractWidget.cpp
@@ -41,8 +41,8 @@ void UFGInteractWidget::SetDefaultFocusWidget(UWidget* focusWidget){ }
 void UFGInteractWidget::SetupDefaultFocus_Implementation(){ }
 void UFGInteractWidget::CopyFactoryClipboard(){ }
 void UFGInteractWidget::PasteFactoryClipboard(){ }
-void UFGInteractWidget::NativeConstruct(){ }
-void UFGInteractWidget::NativeDestruct(){ }
+void UFGInteractWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGInteractWidget::NativeDestruct(){ Super::NativeDestruct(); }
 bool UFGInteractWidget::NativeCanCallInit(){ return bool(); }
 void UFGInteractWidget::NativeTestAndQueueInit(){ }
 void UFGInteractWidget::ClearRestoreFocusGate(){ }

--- a/Source/FactoryGame/Private/UI/FGManufacturingButton.cpp
+++ b/Source/FactoryGame/Private/UI/FGManufacturingButton.cpp
@@ -6,4 +6,4 @@ void UFGManufacturingButton::SetButton( UButton* inButton){ }
 void UFGManufacturingButton::SetHoldTime(float inHoldTime){ }
 void UFGManufacturingButton::OnPressedButton(){ }
 void UFGManufacturingButton::OnReleasedButton(){ }
-void UFGManufacturingButton::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ }
+void UFGManufacturingButton::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ Super::NativeTick(MyGeometry, InDeltaTime); }

--- a/Source/FactoryGame/Private/UI/FGMapObjectWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGMapObjectWidget.cpp
@@ -5,8 +5,8 @@
 bool UFGMapObjectWidget::CanBeHighlighted() const{ return bool(); }
 void UFGMapObjectWidget::SetHighlighted(bool highlighted){ }
 FLinearColor UFGMapObjectWidget::IsHighlighted(bool& out_IsHighlighted,  bool& out_HighlightedByLocalPlayer) const{ return FLinearColor(); }
-void UFGMapObjectWidget::NativeConstruct(){ }
-void UFGMapObjectWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ }
+void UFGMapObjectWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGMapObjectWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime){ Super::NativeTick(MyGeometry, InDeltaTime); }
 void UFGMapObjectWidget::InitMapObject(){ }
 void UFGMapObjectWidget::InitMapObjectPostion(){ }
 void UFGMapObjectWidget::OnActorRepresentationFiltered(ERepresentationType representationType, bool visible){ }

--- a/Source/FactoryGame/Private/UI/FGMapWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGMapWidget.cpp
@@ -2,8 +2,8 @@
 
 #include "UI/FGMapWidget.h"
 
-void UFGMapWidget::NativeConstruct(){ }
-void UFGMapWidget::NativeDestruct(){ }
+void UFGMapWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGMapWidget::NativeDestruct(){ Super::NativeDestruct(); }
 void UFGMapWidget::UpdateFogOfWarTexture(){ }
 void UFGMapWidget::SetupRepresentationManager(){ }
 void UFGMapWidget::BindActorRepresentationManager( AFGActorRepresentationManager* representationManager){ }

--- a/Source/FactoryGame/Private/UI/FGMenuBase.cpp
+++ b/Source/FactoryGame/Private/UI/FGMenuBase.cpp
@@ -8,6 +8,6 @@ UFGMenuBase::UFGMenuBase(const FObjectInitializer& objectInitializer) : Super(ob
 void UFGMenuBase::ReleaseSlateResources(bool bReleaseChildren){ Super::ReleaseSlateResources(bReleaseChildren); }
 void UFGMenuBase::MenuEnter( UWidget* prevMenu){ }
 void UFGMenuBase::MenuExit( UWidget* nextMenu, bool noAnimation){ }
-void UFGMenuBase::NativeConstruct(){ }
+void UFGMenuBase::NativeConstruct(){ Super::NativeConstruct(); }
 void UFGMenuBase::OnMenuEnterDone(){ }
 void UFGMenuBase::OnMenuExitDone(){ }

--- a/Source/FactoryGame/Private/UI/FGOptionsValueController.cpp
+++ b/Source/FactoryGame/Private/UI/FGOptionsValueController.cpp
@@ -18,6 +18,6 @@ FString UFGOptionsValueController::GetSettingIndentifier() const{ return FString
 TArray<FIntegerSelection> UFGOptionsValueController::GetIntegerSelectionValues() const{ return TArray<FIntegerSelection>(); }
 bool UFGOptionsValueController::GetBlockLastIndexFromManualSelection() const{ return bool(); }
 EOptionType UFGOptionsValueController::GetOptionType() const{ return EOptionType(); }
-void UFGOptionsValueController::NativeConstruct(){ }
+void UFGOptionsValueController::NativeConstruct(){ Super::NativeConstruct(); }
 bool UFGOptionsValueController::GetBoolOptionValue(){ return bool(); }
 FOptionRowData UFGOptionsValueController::GetOptionRowData() const{ return FOptionRowData(); }

--- a/Source/FactoryGame/Private/UI/FGPlayerNameTagWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGPlayerNameTagWidget.cpp
@@ -3,5 +3,5 @@
 #include "UI/FGPlayerNameTagWidget.h"
 
 void UFGPlayerNameTagWidget::UpdatePlayerData(FString playerName, FLinearColor playerColor, bool isPlayerOnline, bool useOverrideIcon){ }
-void UFGPlayerNameTagWidget::NativeConstruct(){ }
+void UFGPlayerNameTagWidget::NativeConstruct(){ Super::NativeConstruct(); }
 void UFGPlayerNameTagWidget::OnHiddenHUDModeChanged(bool hideHUD){ }

--- a/Source/FactoryGame/Private/UI/FGSequencerWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGSequencerWidget.cpp
@@ -2,8 +2,8 @@
 
 #include "UI/FGSequencerWidget.h"
 
-void UFGSequencerWidget::NativeConstruct(){ }
-void UFGSequencerWidget::NativeDestruct(){ }
+void UFGSequencerWidget::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGSequencerWidget::NativeDestruct(){ Super::NativeDestruct(); }
 void UFGSequencerWidget::ListenForInput(FInputChord inputkeyChord, TEnumAsByte<EInputEvent> eventType, bool consume, FOnInputAction callback){ }
 void UFGSequencerWidget::StopListeningForAllInputs(){ }
 void UFGSequencerWidget::MoveCursorForward(){ }

--- a/Source/FactoryGame/Private/UI/FGUserWidget.cpp
+++ b/Source/FactoryGame/Private/UI/FGUserWidget.cpp
@@ -7,7 +7,7 @@ DEFINE_LOG_CATEGORY(LogUI);
 #if WITH_EDITOR
 void UFGUserWidget::ValidateCompiledWidgetTree(const UWidgetTree& BlueprintWidgetTree,  IWidgetCompilerLog& CompileLog) const{ }
 #endif 
-void UFGUserWidget::NativeConstruct(){ }
+void UFGUserWidget::NativeConstruct(){ Super::NativeConstruct(); }
 FReply UFGUserWidget::NativeOnPreviewKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent){ return FReply::Unhandled(); }
 FReply UFGUserWidget::NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent){ return FReply::Unhandled(); }
 FReply UFGUserWidget::NativeOnKeyUp(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent){ return FReply::Unhandled(); }

--- a/Source/FactoryGame/Private/UI/Message/FGAudioMessage.cpp
+++ b/Source/FactoryGame/Private/UI/Message/FGAudioMessage.cpp
@@ -23,8 +23,8 @@ UFGAudioMessage::UFGAudioMessage(const FObjectInitializer& ObjectInitializer) : 
 	this->mAudioMessageInputComponent = nullptr;
 	this->mMessage = nullptr;
 }
-void UFGAudioMessage::NativeConstruct(){ }
-void UFGAudioMessage::NativeDestruct(){ }
+void UFGAudioMessage::NativeConstruct(){ Super::NativeConstruct(); }
+void UFGAudioMessage::NativeDestruct(){ Super::NativeDestruct(); }
 int32 UFGAudioMessage::GetMessagePriority() const{ return int32(); }
 void UFGAudioMessage::StartPlayback(){ }
 void UFGAudioMessage::OnSkipButtonPressed(){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGDockingStationInfo.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGDockingStationInfo.cpp
@@ -43,8 +43,8 @@ ECompassViewDistance AFGDockingStationInfo::GetActorCompassViewDistance(){ retur
 void AFGDockingStationInfo::SetActorCompassViewDistance(ECompassViewDistance compassViewDistance){ }
 UMaterialInterface* AFGDockingStationInfo::GetActorRepresentationCompassMaterial(){ return nullptr; }
 void AFGDockingStationInfo::SetBuildingTag_Implementation(const FString& buildingTag){ }
-void AFGDockingStationInfo::BeginPlay(){ }
-void AFGDockingStationInfo::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGDockingStationInfo::BeginPlay(){ Super::BeginPlay(); }
+void AFGDockingStationInfo::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGDockingStationInfo::Init( AFGBuildableDockingStation* station){ }
 void AFGDockingStationInfo::SetStationStatus(EDockingStationStatus status){ }
 void AFGDockingStationInfo::OnRep_Status(){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGSimulatedWheeledVehicle.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGSimulatedWheeledVehicle.cpp
@@ -11,5 +11,5 @@ void AFGSimulatedWheeledVehicle::GetLifetimeReplicatedProps(TArray<FLifetimeProp
 
 }
 void AFGSimulatedWheeledVehicle::Init( AFGWheeledVehicle* vehicle){ }
-void AFGSimulatedWheeledVehicle::BeginPlay(){ }
-void AFGSimulatedWheeledVehicle::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGSimulatedWheeledVehicle::BeginPlay(){ Super::BeginPlay(); }
+void AFGSimulatedWheeledVehicle::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGSplinePathMovementComponent.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGSplinePathMovementComponent.cpp
@@ -32,8 +32,8 @@ void UFGSplinePathMovementComponent::GetLifetimeReplicatedProps(TArray<FLifetime
 	DOREPLIFETIME(UFGSplinePathMovementComponent, mServerPauseTime);
 	DOREPLIFETIME(UFGSplinePathMovementComponent, mIsMoving);
 }
-void UFGSplinePathMovementComponent::BeginPlay(){ }
-void UFGSplinePathMovementComponent::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void UFGSplinePathMovementComponent::BeginPlay(){ Super::BeginPlay(); }
+void UFGSplinePathMovementComponent::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void UFGSplinePathMovementComponent::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction){ }
 void UFGSplinePathMovementComponent::TicTac(float DeltaTime){ }
 void UFGSplinePathMovementComponent::OnBecameTheChosenWheeledVehicle(){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGTargetPoint.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGTargetPoint.cpp
@@ -4,7 +4,7 @@
 #include "Net/UnrealNetwork.h"
 
 #if DEBUG_SELF_DRIVING
-void AFGTargetPoint::Tick(float DeltaSeconds){ }
+void AFGTargetPoint::Tick(float DeltaSeconds){ Super::Tick(DeltaSeconds); }
 #endif 
 AFGTargetPoint::AFGTargetPoint() : Super() {
 	this->mOwningList = nullptr;
@@ -58,8 +58,8 @@ bool AFGTargetPoint::IsLockedByDocking(const  AFGWheeledVehicleInfo* vehicle) co
 void AFGTargetPoint::DrawTargetDebug( AFGWheeledVehicleInfo* claimant, bool drawSearchPoints, bool drawSmall){ }
 int AFGTargetPoint::GetDebugLevel() const{ return int(); }
 void AFGTargetPoint::FindBlockingVehicles( AFGWheeledVehicleInfo* blockedVehicle, TSet< const  AFGWheeledVehicleInfo* >& blockingVehicles) const{ }
-void AFGTargetPoint::BeginPlay(){ }
-void AFGTargetPoint::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGTargetPoint::BeginPlay(){ Super::BeginPlay(); }
+void AFGTargetPoint::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGTargetPoint::OnRep_IsLoopTarget(){ }
 void AFGTargetPoint::OnRep_IsDockingTarget(){ }
 void AFGTargetPoint::OnRep_TargetSpeed(){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGTargetPointLinkedList.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGTargetPointLinkedList.cpp
@@ -30,8 +30,8 @@ void AFGDrivingTargetList::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>&
 }
 void AFGDrivingTargetList::PostLoadGame_Implementation(int32 saveVersion, int32 gameVersion){ }
 bool AFGDrivingTargetList::ShouldSave_Implementation() const{ return bool(); }
-void AFGDrivingTargetList::BeginPlay(){ }
-void AFGDrivingTargetList::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
+void AFGDrivingTargetList::BeginPlay(){ Super::BeginPlay(); }
+void AFGDrivingTargetList::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
 void AFGDrivingTargetList::CreatePath(){ }
 void AFGDrivingTargetList::DestroyPath_Server(){ }
 void AFGDrivingTargetList::DestroyLocalActors(){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicle.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicle.cpp
@@ -76,10 +76,10 @@ AFGWheeledVehicle::AFGWheeledVehicle() : Super() {
 	this->mFoliageCollideBox->SetupAttachment(mMesh);
 }
 void AFGWheeledVehicle::PostInitializeComponents(){ Super::PostInitializeComponents(); }
-void AFGWheeledVehicle::BeginPlay(){ }
-void AFGWheeledVehicle::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGWheeledVehicle::Destroyed(){ }
-void AFGWheeledVehicle::Tick(float dt){ }
+void AFGWheeledVehicle::BeginPlay(){ Super::BeginPlay(); }
+void AFGWheeledVehicle::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGWheeledVehicle::Destroyed(){ Super::Destroyed(); }
+void AFGWheeledVehicle::Tick(float dt){ Super::Tick(dt); }
 void AFGWheeledVehicle::DisplayDebug(UCanvas* canvas, const FDebugDisplayInfo& debugDisplay, float& YL, float& YPos){ }
 bool AFGWheeledVehicle::DriverEnter(AFGCharacterPlayer* driver){ return bool(); }
 bool AFGWheeledVehicle::DriverLeave(bool keepDriving){ return bool(); }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicleAIController.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicleAIController.cpp
@@ -11,7 +11,7 @@ AFGWheeledVehicleAIController::AFGWheeledVehicleAIController() : Super() {
 void AFGWheeledVehicleAIController::OnPossess(APawn* InPawn){ }
 void AFGWheeledVehicleAIController::OnUnPossess(){ }
 const FString& AFGWheeledVehicleAIController::GetCurrentPlanName() const{ return *(new FString); }
-void AFGWheeledVehicleAIController::Tick(float DeltaTime){ }
+void AFGWheeledVehicleAIController::Tick(float DeltaTime){ Super::Tick(DeltaTime); }
 void AFGWheeledVehicleAIController::CalculateInput(float deltaTime, Input& input) const{ }
 AFGWheeledVehicleAIController::Plan AFGWheeledVehicleAIController::PickPlan(const Input& input) const{ return Plan(); }
 void AFGWheeledVehicleAIController::Halt(const Input& input, Output& output){ }

--- a/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicleInfo.cpp
+++ b/Source/FactoryGame/Private/WheeledVehicles/FGWheeledVehicleInfo.cpp
@@ -80,9 +80,9 @@ float AFGWheeledVehicleInfo::GetActorFogOfWarRevealRadius(){ return float(); }
 ECompassViewDistance AFGWheeledVehicleInfo::GetActorCompassViewDistance(){ return ECompassViewDistance(); }
 void AFGWheeledVehicleInfo::SetActorCompassViewDistance(ECompassViewDistance compassViewDistance){ }
 UMaterialInterface* AFGWheeledVehicleInfo::GetActorRepresentationCompassMaterial(){ return nullptr; }
-void AFGWheeledVehicleInfo::BeginPlay(){ }
-void AFGWheeledVehicleInfo::EndPlay(const EEndPlayReason::Type EndPlayReason){ }
-void AFGWheeledVehicleInfo::Tick(float dt){ }
+void AFGWheeledVehicleInfo::BeginPlay(){ Super::BeginPlay(); }
+void AFGWheeledVehicleInfo::EndPlay(const EEndPlayReason::Type endPlayReason){ Super::EndPlay(endPlayReason); }
+void AFGWheeledVehicleInfo::Tick(float dt){ Super::Tick(dt); }
 void AFGWheeledVehicleInfo::Init(AFGWheeledVehicle* vehicle){ }
 void AFGWheeledVehicleInfo::InitCollisionData(){ }
 AFGWheeledVehicle* AFGWheeledVehicleInfo::GetVehicle() const{ return nullptr; }


### PR DESCRIPTION
Add calls to Super functions for actors, actor components and widgets. Even if the implementation is still incomplete, this should allow objects of FG classes to function better inside the editor.

For example, BP widgets derived from UFGInteractWidget should now receive Construct, Destruct and Tick events.