### PR TITLE
Validate ModSubsystems in GameWorldModule

### DIFF
--- a/Mods/SML/Source/SML/Private/Module/GameWorldModule.cpp
+++ b/Mods/SML/Source/SML/Private/Module/GameWorldModule.cpp
@@ -21,6 +21,12 @@ EDataValidationResult UGameWorldModule::IsDataValid(TArray<FText>& ValidationErr
 			ValidationResult = EDataValidationResult::Invalid;
 		}
 	}
+	for (const TSubclassOf<AModSubsystem>& Subsystem : ModSubsystems) {
+		if (Subsystem == nullptr) {
+			ValidationErrors.Add(NSLOCTEXT("GameWorldModule", "Validation_NullModSubsystem", "Null ModSubsystem found. Was the content it previously referenced deleted or moved?"));
+			ValidationResult = EDataValidationResult::Invalid;
+		}
+	}
 
 	return ValidationResult;
 }


### PR DESCRIPTION
SML will crash if a mod references a null mod subsystem class in a GameWorldModule. Add an editor check to catch this.