### PR TITLE
Alpakit: Generalise hiding editor-only mods

### DIFF
--- a/Mods/Alpakit/Source/Alpakit/Private/AlpakitModEntryList.cpp
+++ b/Mods/Alpakit/Source/Alpakit/Private/AlpakitModEntryList.cpp
@@ -146,13 +146,19 @@ bool DoesPluginHaveRuntime(const IPlugin& Plugin) {
     return false;
 }
 
-const TSet<FString> HiddenMods = { TEXT("SMLEditor") };
+static bool IsPluginEditorOnly(const IPlugin& Plugin) {
+    if (TSharedPtr<FJsonObject> Json = Plugin.GetDescriptor().CachedJson) {
+        bool Result = false;
+        return Json->TryGetBoolField("EditorOnly", Result) && Result;
+    }
+    return false;
+}
 
 void SAlpakitModEntryList::LoadMods() {
     Mods.Empty();
     const TArray<TSharedRef<IPlugin>> EnabledPlugins = IPluginManager::Get().GetEnabledPlugins();
     for (TSharedRef<IPlugin> Plugin : EnabledPlugins) {
-        if (HiddenMods.Contains(Plugin->GetName())) {
+        if (IsPluginEditorOnly(Plugin.Get())) {
             continue;
         }
         

--- a/Mods/SMLEditor/SMLEditor.uplugin
+++ b/Mods/SMLEditor/SMLEditor.uplugin
@@ -11,6 +11,7 @@
 	"DocsURL": "https://docs.ficsit.app",
 	"MarketplaceURL": "",
 	"SupportURL": "",
+	"EditorOnly": true,
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
Instead of having a hardcoded list of editor-only mods to not show in the Alpakit mod list, allow mods to set an "EditorOnly" bool property in the .uplugin to hide them in Alpakit.