### PR TITLE
Dont mark content as BuiltIn if its not from the basegame

### DIFF
--- a/Mods/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
+++ b/Mods/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
@@ -156,13 +156,15 @@ EGameObjectRegistrationFlags FGameObjectRegistryState::GetAllowedNewFlags(UObjec
 
 	// Never allow Removed, since it's handled by MarkObjectAsRemoved
 
+	static FName baseGameProjectName = FApp::GetProjectName();
+
 	EGameObjectRegistrationFlags allowedFlags = EGameObjectRegistrationFlags::None;
 
-	if ( IsBuildIn( Object ) ) {
+	if ( !Registration || Registration->OwnedByModReference == baseGameProjectName ) {
 		allowedFlags |= EGameObjectRegistrationFlags::BuiltIn;
 	}
 
-	if (!Registration || Registration->HasAnyFlags(EGameObjectRegistrationFlags::Unregistered | EGameObjectRegistrationFlags::Implicit))
+	if ( !Registration || Registration->HasAnyFlags(EGameObjectRegistrationFlags::Unregistered | EGameObjectRegistrationFlags::Implicit) )
 	{
 		// Allow Implicit only on unregistered objects, or if it is already set
 		// so that is is kept when re-registering as Implicit
@@ -170,16 +172,6 @@ EGameObjectRegistrationFlags FGameObjectRegistryState::GetAllowedNewFlags(UObjec
 	}
 
 	return allowedFlags;
-}
-
-bool FGameObjectRegistryState::IsBuildIn(UObject* Object) {
-	UPackage* package = Object->GetPackage();
-
-	if ( !IsValid( package ) ) {
-		return false;
-	}
-
-	return package->FileName.ToString().StartsWith("/Game/FactoryGame/");
 }
 
 bool FGameObjectRegistryState::AttemptRegisterObject( FName InRegistrationPluginName, UObject* Object, EGameObjectRegistrationFlags ExtraFlags )

--- a/Mods/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
+++ b/Mods/SML/Source/SML/Private/Registry/ModContentRegistry.cpp
@@ -151,17 +151,35 @@ EGameObjectRegistrationFlags FGameObjectRegistryState::GetAllowedNewFlags(UObjec
 	{
 		return EGameObjectRegistrationFlags::None;
 	}
+
 	const FGameObjectRegistration* Registration = FindObjectRegistration( Object );
 
 	// Never allow Removed, since it's handled by MarkObjectAsRemoved
-	
-	if ( !Registration || Registration->HasAnyFlags(EGameObjectRegistrationFlags::Unregistered | EGameObjectRegistrationFlags::Implicit) )
+
+	EGameObjectRegistrationFlags allowedFlags = EGameObjectRegistrationFlags::None;
+
+	if ( IsBuildIn( Object ) ) {
+		allowedFlags |= EGameObjectRegistrationFlags::BuiltIn;
+	}
+
+	if (!Registration || Registration->HasAnyFlags(EGameObjectRegistrationFlags::Unregistered | EGameObjectRegistrationFlags::Implicit))
 	{
 		// Allow Implicit only on unregistered objects, or if it is already set
 		// so that is is kept when re-registering as Implicit
-		return EGameObjectRegistrationFlags::Implicit | EGameObjectRegistrationFlags::BuiltIn;
+		allowedFlags |= EGameObjectRegistrationFlags::Implicit;
 	}
-	return EGameObjectRegistrationFlags::BuiltIn;
+
+	return allowedFlags;
+}
+
+bool FGameObjectRegistryState::IsBuildIn(UObject* Object) {
+	UPackage* package = Object->GetPackage();
+
+	if ( !IsValid( package ) ) {
+		return false;
+	}
+
+	return package->FileName.ToString().StartsWith("/Game/FactoryGame/");
 }
 
 bool FGameObjectRegistryState::AttemptRegisterObject( FName InRegistrationPluginName, UObject* Object, EGameObjectRegistrationFlags ExtraFlags )
@@ -323,7 +341,6 @@ void UModContentRegistry::ModifySchematicList(TArray<TSubclassOf<UFGSchematic>>&
 		});
 	}
 }
-
 
 void UModContentRegistry::ModifySchematicListInternal( TArray<TSubclassOf<UFGSchematic>>& RefSchematics )
 {

--- a/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -109,6 +109,7 @@ private:
 	FGameObjectRegistration* FindOrAddObject( UObject* Object );
 	bool CanRegisterObject( UObject* Object, EGameObjectRegistrationFlags ExtraFlags, FString& OutMessage );
 	EGameObjectRegistrationFlags GetAllowedNewFlags( UObject* Object ) const;
+	static bool IsBuildIn(UObject* Object);
 };
 
 // Holds information about a pending registration of item points table to the resource sink subsystem

--- a/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
+++ b/Mods/SML/Source/SML/Public/Registry/ModContentRegistry.h
@@ -109,7 +109,6 @@ private:
 	FGameObjectRegistration* FindOrAddObject( UObject* Object );
 	bool CanRegisterObject( UObject* Object, EGameObjectRegistrationFlags ExtraFlags, FString& OutMessage );
 	EGameObjectRegistrationFlags GetAllowedNewFlags( UObject* Object ) const;
-	static bool IsBuildIn(UObject* Object);
 };
 
 // Holds information about a pending registration of item points table to the resource sink subsystem


### PR DESCRIPTION
Currently SML lets mods register their content, content registration automatically traverses dependencies from research tree > schematic > recipe > item, this way if a mod for example adds a new recipe for `iron plates` it will be registered as if the mod owns it

After that SML will do a pass with all schematics from the base game, and it will force update anything referenced by these base game schematics to also be considered as part of the base game

This causes an issue when you set a mod schematic as an unlock dependency for an base game schematic, for example if a mod adds an milestone schematic that gives earlier access to pipes, and that mod wants to make sure that when that milestone is obtained the player can also buy the clear pipes variant, the mod would need to CDO edit the clear pipes unlock dependency to point to its mod milestone schematic, This however causes the mod milestone schematic to be force marked as part of the base game, and that results in it not getting properly registered and become unusable by the player

This PR makes sure that only content actually from the base game can be marked as coming from the base game

Fix for #248 