### PR TITLE
Ability to climb up the parent tree for widget blueprint hooking

### DIFF
--- a/Mods/SML/Source/SML/Public/Patching/WidgetBlueprintHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/WidgetBlueprintHookManager.h
@@ -30,10 +30,10 @@ enum class EWidgetBlueprintHookParentType : uint8 {
 };
 
 namespace WidgetBlueprintHookParentValidator {
-	SML_API bool ValidateParentWidget(UWidget* Widget, EWidgetBlueprintHookParentType ParentType, UPanelWidget*& OutParentWidget, bool bCheckVariableName = true);
+	SML_API bool ValidateParentWidget(UWidget* Widget, EWidgetBlueprintHookParentType ParentType, UPanelWidget*& OutParentWidget, bool bCheckVariableName = true, FName ParentNameToCheck = FName{});
 
 	SML_API bool ValidateDirectWidget(UWidget* Widget, UPanelWidget*& OutPanelWidget, bool bCheckVariableName);
-	SML_API bool ValidateIndirectChildWidget(UWidget* Widget, UPanelWidget*& OutPanelWidget, bool bCheckVariableName);
+	SML_API bool ValidateIndirectChildWidget(UWidget* Widget, UPanelWidget*& OutPanelWidget, bool bCheckVariableName, FName ParentNameToCheck = FName{});
 	SML_API bool ValidateWidgetBase(UWidget* Widget, bool bCheckVariableName);
 }
 
@@ -76,9 +76,16 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Advanced")
 	EWidgetBlueprintHookParentType ParentWidgetType;
 	
-	/** Name of the parent widget variable to attach this widget to. Must a panel widget. */
+	/**
+	 * Name of the parent widget variable to attach this widget to. Must a panel widget.
+	 * If ParentWidgetType is Indirect (Child), this is the name of the child widget variable to search for the parents.
+	 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Default", meta = (GetOptions = "GetParentWidgetNames"))
 	FName ParentWidgetName;
+
+	/** Name of the parent widget to attach this widget to when ParentWidgetType is Indirect (Child) */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Advanced", meta = (EditCondition = "ParentWidgetType == EWidgetBlueprintHookParentType::Indirect_Child", GetOptions = "GetIndirectParentWidgetNames"))
+	FName IndirectParentWidgetNameToAttachTo;
 
 	/**
 	 * When not -1, specifies the index in the parent widget Slots array at which the widget will be inserted
@@ -100,6 +107,9 @@ public:
 
 	UFUNCTION(BlueprintPure)
 	TArray<FString> GetParentWidgetNames() const;
+
+	UFUNCTION(BlueprintPure)
+	TArray<FString> GetIndirectParentWidgetNames() const;
 	
 	/** Updates the blueprint widget class being hooked */
 	UFUNCTION(BlueprintSetter)
@@ -119,10 +129,14 @@ public:
 	/** Updates the name of the parent widget for this hook */
 	UFUNCTION(BlueprintSetter)
 	void SetParentWidgetName(FName InParentWidgetName);
+
+	/** Updates the name of the parent widget for this hook when ParentWidgetType is Indirect (Child) */
+	UFUNCTION(BlueprintSetter)
+	void SetIndirectParentWidgetNameToAttachTo(FName InIndirectParentWidgetNameToAttachTo);
 	
 	void ReinitializeNewWidgetTemplate();
 	void ReinitializePanelSlotTemplate();
-	UPanelWidget* ResolveParentWidget() const;
+	UPanelWidget* ResolveParentWidget(bool bFollowIndirectParents = false) const;
 };
 
 UCLASS()


### PR DESCRIPTION
Previously, when the parent type is "Indirect (Child)", you could only choose the immediate parents of the widget variables for the widget to attach the new widget to. Now you can choose the grandparents too.

For instance, if the widget looks like this,
![image](https://github.com/user-attachments/assets/da599b65-c77f-4278-bfbe-e93f1240004d)
there was no (easy) way to add a widget to the vertical box or the overlay.

With this pull request, you can choose them like this.
![image](https://github.com/user-attachments/assets/dfe4b4a0-b782-4349-8365-f7894acf24c1)
