### PR TITLE
Changed the open folder from text to an icon.

### DIFF
--- a/Mods/Alpakit/Source/Alpakit/Private/AlpakitReleaseWidget.cpp
+++ b/Mods/Alpakit/Source/Alpakit/Private/AlpakitReleaseWidget.cpp
@@ -196,7 +196,11 @@ void SAlpakitReleaseWidget::Construct(const FArguments& InArgs) {
 								})
 							.Content()[
 								SNew(SButton)
-								.Text(LOCTEXT("OpenDirAlpakit", "Open Folder"))
+								.Content()
+								[
+									SNew(SImage)
+									.Image(FAlpakitStyle::Get().GetBrush("Alpakit.FolderOpen"))
+								]
 								.OnClicked_Lambda([this, modPath]
 									{
 										FPlatformProcess::ExploreFolder(*modPath);

--- a/Mods/Alpakit/Source/Alpakit/Private/AlpakitReleaseWidget.cpp
+++ b/Mods/Alpakit/Source/Alpakit/Private/AlpakitReleaseWidget.cpp
@@ -49,7 +49,7 @@ void SAlpakitReleaseWidget::Construct(const FArguments& InArgs) {
 							return EVisibility::Visible;
 						return EVisibility::Hidden;
 					})
-					.ToolTipText(LOCTEXT("PackageDirRootAlpakit_Tooltip", "Opens the ArchivedPlugins Folder to view all built plugins."))
+					.ToolTipText(LOCTEXT("PackageDirRootAlpakit_Tooltip", "Open the ArchivedPlugins folder to view all mod release packages."))
 				]
 			]
 			.SearchTrail() [
@@ -210,7 +210,7 @@ void SAlpakitReleaseWidget::Construct(const FArguments& InArgs) {
 									{
 										return !FAlpakitModule::Get().IsPackaging();
 									})
-								.ToolTipText(LOCTEXT("OpenDirToolTip", "Opens the Mod's ArchivedPlugins directory in File Explorer"))
+								.ToolTipText(LOCTEXT("OpenDirToolTip", "Open the mod's ArchivedPlugins directory in File Explorer, which contains the multi-target zip file to upload to the Satisfactory Mod Repository."))
 							]
 						]
 						+ SHorizontalBox::Slot().AutoWidth().Padding(5,0)[

--- a/Mods/Alpakit/Source/Alpakit/Private/AlpakitStyle.cpp
+++ b/Mods/Alpakit/Source/Alpakit/Private/AlpakitStyle.cpp
@@ -55,7 +55,7 @@ TSharedRef<FSlateStyleSet> FAlpakitStyle::Create() {
 	Style->SetCoreContentRoot(FPaths::EngineContentDir() / TEXT("Slate"));
 
     Style->Set("Alpakit.Warning", new IMAGE_BRUSH("Icons/alert", Icon16x16) );
-    
+	Style->Set("Alpakit.FolderOpen", new IMAGE_BRUSH("Icons/icon_file_ProjectOpen_16x", Icon16x16));
     return Style;
 }
 


### PR DESCRIPTION
Update for PR 287 to use an icon instead of text for the open mod folder button, similar to the alerts for game version targeting.