### PR TITLE
Add ExecCmds functionality for Shipping builds

### DIFF
--- a/Mods/SML/Source/SML/Private/SMLModule.cpp
+++ b/Mods/SML/Source/SML/Private/SMLModule.cpp
@@ -30,6 +30,9 @@ void FSMLModule::StartupModule() {
 	//UObject subsystem and Engine are initialized on PostEngineInit and we need to delay their initialization to that moment
 	FCoreDelegates::OnPostEngineInit.AddStatic(FSatisfactoryModLoader::InitializeModLoading);
 
+	// ExecCmds are run after Engine is initialized as they use GEngine to run the commands
+	FCoreDelegates::OnPostEngineInit.AddStatic(FSatisfactoryModLoader::ParseExecCmds);
+
 	RegisterPluginGameplayTagInis();
 }
 

--- a/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
+++ b/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
@@ -17,6 +17,7 @@
 #include "Misc/FileHelper.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
+#include "ParseExecCommands.h"
 
 #ifndef FACTORYGAME_VERSION
 #define FACTORYGAME_VERSION 0

--- a/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
+++ b/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
@@ -220,7 +220,7 @@ void FSatisfactoryModLoader::InitializeModLoading() {
 void FSatisfactoryModLoader::ParseExecCmds()
 {
     //ExecCmds is run natively by UE on non-Shipping builds so we only want to run it when it is Shipping
-#if UE_BUILD_SHIPPING || !(ENABLE_PGO_PROFILE)
+#if UE_BUILD_SHIPPING && !(ENABLE_PGO_PROFILE)
     UE_LOG(LogSatisfactoryModLoader, Display, TEXT("Parsing ExecCmds"));
     ParseExecCommands::QueueDeferredCommands(ParseExecCommands::ParseExecCmdsFromCommandLine(TEXT("ExecCmds")));
 #endif

--- a/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
+++ b/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
@@ -216,3 +216,12 @@ void FSatisfactoryModLoader::InitializeModLoading() {
     }
     UE_LOG(LogSatisfactoryModLoader, Display, TEXT("Initialization finished!"));
 }
+
+void FSatisfactoryModLoader::ParseExecCmds()
+{
+    //ExecCmds is run natively by UE on non-Shipping builds so we only want to run it when it is Shipping
+#if UE_BUILD_SHIPPING || !(ENABLE_PGO_PROFILE)
+    UE_LOG(LogSatisfactoryModLoader, Display, TEXT("Parsing ExecCmds"));
+    ParseExecCommands::QueueDeferredCommands(ParseExecCommands::ParseExecCmdsFromCommandLine(TEXT("ExecCmds")));
+#endif
+}

--- a/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
+++ b/Mods/SML/Source/SML/Private/SatisfactoryModLoader.cpp
@@ -220,7 +220,7 @@ void FSatisfactoryModLoader::InitializeModLoading() {
 
 void FSatisfactoryModLoader::ParseExecCmds()
 {
-    //ExecCmds is run natively by UE on non-Shipping builds so we only want to run it when it is Shipping
+    //ExecCmds is run natively by UE on non-Shipping builds, so we only want to run our reimplementation when in Shipping (in case CSS enables it later)
 #if UE_BUILD_SHIPPING && !(ENABLE_PGO_PROFILE)
     UE_LOG(LogSatisfactoryModLoader, Display, TEXT("Parsing ExecCmds"));
     ParseExecCommands::QueueDeferredCommands(ParseExecCommands::ParseExecCmdsFromCommandLine(TEXT("ExecCmds")));

--- a/Mods/SML/Source/SML/Public/SatisfactoryModLoader.h
+++ b/Mods/SML/Source/SML/Public/SatisfactoryModLoader.h
@@ -45,4 +45,7 @@ private:
 
 	/** Finishes mod loading and mounts packages, initializes subsystems, loads mod configurations, etc */
 	static void InitializeModLoading();
+
+	/** Runs console commands using the ExecCmds flag */
+	static void ParseExecCmds();
 };

--- a/Mods/SML/Source/SML/Public/SatisfactoryModLoader.h
+++ b/Mods/SML/Source/SML/Public/SatisfactoryModLoader.h
@@ -46,6 +46,6 @@ private:
 	/** Finishes mod loading and mounts packages, initializes subsystems, loads mod configurations, etc */
 	static void InitializeModLoading();
 
-	/** Runs console commands using the ExecCmds flag */
+	/** Runs console commands using the ExecCmds argument (reimplementation; existing UE ExecCmds doesn't work in shipping) */
 	static void ParseExecCmds();
 };


### PR DESCRIPTION
Added ExecCmds to SML which can be used in a Shipping build. Won't be run on non-Shipping builds. 