### PR TITLE
Make configuration texts localizable

### DIFF
--- a/Mods/SML/Source/SML/Public/Configuration/ConfigProperty.h
+++ b/Mods/SML/Source/SML/Public/Configuration/ConfigProperty.h
@@ -22,11 +22,11 @@ class SML_API UConfigProperty : public UObject {
 public:
     /** Display name of this property as it is visible to the user */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Configuration Property")
-    FString DisplayName;
+    FText DisplayName;
 
     /** Tooltip visible to user hovering over this property */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Configuration Property", meta = (MultiLine = true))
-    FString Tooltip;
+    FText Tooltip;
 
 	/** Whenever this value is only editable from main menu and disabled for editing in pause menu */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Configuration Property")
@@ -34,7 +34,7 @@ public:
 
 	/** Whenever this value should be hidden in Widgets ( No User Input )  */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Configuration Property")
-		uint8 bHidden : 1;
+	uint8 bHidden : 1;
 
 	/** Describes value of this property for debugging purposes */
 	UFUNCTION(BlueprintPure, BlueprintNativeEvent)

--- a/Mods/SML/Source/SML/Public/Configuration/ModConfiguration.h
+++ b/Mods/SML/Source/SML/Public/Configuration/ModConfiguration.h
@@ -36,11 +36,11 @@ public:
     
     /** Display name of this configuration, as it will be visible to user */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-    FString DisplayName;
+    FText DisplayName;
     
     /** Description of this configuration, can be empty */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-    FString Description;
+    FText Description;
 
     /** Root property of this configuration describing its values */
     UPROPERTY(EditDefaultsOnly, Instanced, BlueprintReadOnly)
@@ -48,7 +48,7 @@ public:
 
 	/** Custom Widget - placed at the Bottom of the Mod Config Widgets*/
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
-		TSubclassOf<UUserWidget> CustomWidget;
+	TSubclassOf<UUserWidget> CustomWidget;
 
 #if WITH_EDITOR
     virtual EDataValidationResult IsDataValid(TArray<FText>& ValidationErrors) override;


### PR DESCRIPTION
The `DisplayName` and `Tootltip` of `ModConfiguration` and `ConfigProperty` were `FString`, which isn't localizable, so changed them to be `FText`.

Tested with an existing mod, the values of the fields were preserved, this change is backwards compatible.

End Result (Localization: Korean):
![image](https://github.com/user-attachments/assets/e0d04cb2-3f2b-4215-b82f-f20c7c8c4834)