### PR TITLE
Log mod versions while initializing

### DIFF
--- a/Mods/SML/Source/SML/Private/ModLoading/ModLoadingLibrary.cpp
+++ b/Mods/SML/Source/SML/Private/ModLoading/ModLoadingLibrary.cpp
@@ -149,6 +149,11 @@ void UModLoadingLibrary::Initialize(FSubsystemCollectionBase& Collection) {
     //Initialize metadata and check dependencies for plugins that have already been loaded
     ReloadPluginMetadata();
     VerifyPluginDependencies();
+
+    UE_LOG(LogSatisfactoryModLoader, Display, TEXT("List of loaded mods:"));
+    for (const FModInfo& ModInfo : GetLoadedMods()) {
+        UE_LOG(LogSatisfactoryModLoader, Display, TEXT("%s: %s"), *ModInfo.Name, *ModInfo.Version.ToString());
+    }
 }
 
 FSMLPluginDescriptorMetadata UModLoadingLibrary::FindMetadataOrFallback(IPlugin& Plugin) {


### PR DESCRIPTION
Oftentimes, we only get the log files, no `.smmprofile` or any other file.
Sometimes we can't even contact the original poster to ask their mod versions.
Most of the times we can, but we can save the round-trip time of asking and getting answers.

Example Output:
```
(...)
[2025.01.31-00.43.35:843][  0]LogOnlineIntegration: Initialized 'Epic' online backend
[2025.01.31-00.43.35:843][  0]LogCommonUser: HandleNetworkConnectionStatusChanged(Context:Platform, ServiceName:, OldStatus:NotConnected, NewStatus:NotConnected)
[2025.01.31-00.43.35:843][  0]LogCommonUser: HandleNetworkConnectionStatusChanged(Context:CrossPlay, ServiceName:, OldStatus:NotConnected, NewStatus:Connected)
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: List of loaded mods:
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: AltRecipeResearch: 1.1.1
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: AutoDownloadProgressItems: 1.0.1
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: minerplus: 4.0.8
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: BeltToHUB: 1.0.6
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: BuildableResourceNodesRedux: 2.4.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: ContainerWithScreen: 1.0.1
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: DigitalStorage: 1.2.9
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: EfficiencyCheckerMod: 2.5.10
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: EnhancedDepot: 1.0.1
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: EnhancedSorting: 1.0.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: ExampleMod: 1.0.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: FasterManualCraftingRedux: 2.3.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: GatewaysExtension: 1.3.1
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: AsgGrapplingHook: 1.0.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: InfiniteNudge: 2.3.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: InfiniteZoop: 1.8.18
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: InfiniteSpline: 1.7.6
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: InventorySpace: 2.0.8
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: InventorySpace2: 2.0.8
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: LinearMotion: 2.0.34
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: LinearOverclock: 1.0.9
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: MAMTips: 1.7.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: MapFunctionLibrary: 1.0.2
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: MarcioCommonLibs: 1.3.8
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: MiniMap: 1.1.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: ModUpdateNotifier: 2.1.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: LoadBalancers: 1.15.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: ModularUI: 2.1.31
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: NPMRedux: 1.0.8
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: PowerChecker: 2.4.7
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: RefinedPower: 4.0.32
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: RefinedRDApi: 1.0.5
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: RefinedRDLib: 1.1.36
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: FactoryGame: 385279.0.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: SML: 3.9.0
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: ShopForShardsAndHD: 1.0.6
[2025.01.31-00.43.35:846][  0]LogSatisfactoryModLoader: Display: teleportitem: 2.1.7
[2025.01.31-00.43.35:847][  0]LogSatisfactoryModLoader: Display: DirectToSplitter: 1.2.3
[2025.01.31-00.43.35:847][  0]LogSatisfactoryModLoader: Display: StorageOnBelt: 1.0.3
[2025.01.31-00.43.35:847][  0]LogSatisfactoryModLoader: Display: Th3SwiftSwim: 1.1.1
[2025.01.31-00.43.35:847][  0]LogSatisfactoryModLoader: Display: VanillaGreenHouse: 1.4.7
[2025.01.31-00.43.36:806][  0]LogPakFile: Precache HighWater 16MB

(...)
```