### PR TITLE
Add BlueprintType Access Transformer option

### DIFF
--- a/Mods/AccessTransformers/Source/AccessTransformers/Private/AccessTransformersSubsystem.cpp
+++ b/Mods/AccessTransformers/Source/AccessTransformers/Private/AccessTransformersSubsystem.cpp
@@ -89,6 +89,40 @@ UFunction* FFunctionReference::Resolve(FString& OutError, FString& OutWarning) c
 	return ResolvedFunction;
 }
 
+FUStructReference FUStructReference::FromConfigString(const FString& String)
+{
+	FUStructReference StructReference;
+	StaticStruct()->ImportText(
+		*String,
+		&StructReference,
+		nullptr,
+		PPF_None,
+		nullptr,
+		StaticStruct()->GetName()
+	);
+	return StructReference;
+}
+
+UStruct* FUStructReference::Resolve(FString& OutError, FString& OutWarning) const
+{
+	UStruct* ResolvedStruct = FindObject<UStruct>(nullptr, *Struct);
+	if (!ResolvedStruct) {
+		// Backwards compatibility for old structure (no package, allow source class name)
+		ResolvedStruct = FindStructBySourceName(*Struct);
+		if (!ResolvedStruct) {
+			OutError = FString::Printf(TEXT("Could not find struct %s"), *Struct);
+			return nullptr;
+		}
+		OutWarning = FString::Printf(
+			TEXT(
+				"Using deprecated class specification. The loaded struct was %s. Please update your AccessTransformers config file. This will become an error in a future version."
+			), *ResolvedStruct->GetPathName());
+	}
+
+	return ResolvedStruct;
+}
+
+
 void UAccessTransformersSubsystem::Initialize(FSubsystemCollectionBase& Collection) {
 	Super::Initialize(Collection);
 
@@ -219,6 +253,12 @@ bool UAccessTransformersSubsystem::GetAccessTransformersForPlugin(IPlugin& Plugi
 		OutPluginAccessTransformers.EditAnywhere.Add(FPropertyReference::FromConfigString(ConfigValue.GetValue()));
 	}
 
+	TArray<FConfigValue> BlueprintType;
+	AccessTransformersSection->MultiFind(TEXT("BlueprintType"), BlueprintType);
+	for (const FConfigValue& ConfigValue : BlueprintType) {
+		OutPluginAccessTransformers.BlueprintType.Add(FUStructReference::FromConfigString(ConfigValue.GetValue()));
+	}
+
 	return true;
 }
 
@@ -294,6 +334,27 @@ void UAccessTransformersSubsystem::ApplyTransformers() {
 			Property->ClearPropertyFlags(CPF_DisableEditOnInstance);
 		}
 	}
+
+	for (const auto& PluginTransformers : AccessTransformers) {
+		for (const FUStructReference& EDOStructReference : PluginTransformers.Value.BlueprintType) {
+			FString Error, Warning;
+			UStruct* Struct = EDOStructReference.Resolve(Error, Warning);
+			if (!Warning.IsEmpty()) {
+				UE_LOG(LogAccessTransformers, Warning, TEXT("Resolving BlueprintType %s requested by %s: %s"), *ToString(EDOStructReference), *PluginTransformers.Key, *Warning);
+			}
+			if (!Struct) {
+				UE_LOG(LogAccessTransformers, Error, TEXT("Could not resolve struct for BlueprintType %s requested by %s: %s"), *ToString(EDOStructReference), *PluginTransformers.Key, *Error);
+				continue;
+			}
+
+			if (!OriginalStructMetadata.Contains(Struct))
+			{
+				OriginalStructMetadata.Add(Struct, Struct->GetMetaData(TEXT("BlueprintType")));
+			}
+
+			Struct->SetMetaData(TEXT("BlueprintType"), TEXT("true"));
+		}
+	}
 }
 
 void UAccessTransformersSubsystem::Reset() {
@@ -308,6 +369,11 @@ void UAccessTransformersSubsystem::Reset() {
         Function.Key->FunctionFlags = Function.Value;
     }
 	OriginalFunctionFlags.Empty();
+
+	for (const TTuple<UStruct*, FString>& Struct : OriginalStructMetadata) {
+		Struct.Key->SetMetaData(TEXT("BlueprintType"), *Struct.Value);
+	}
+	OriginalStructMetadata.Empty();
 }
 
 const TCHAR* UAccessTransformersSubsystem::AccessTransformersFileName = TEXT("AccessTransformers.ini");

--- a/Mods/AccessTransformers/Source/AccessTransformers/Public/AccessTransformersSubsystem.h
+++ b/Mods/AccessTransformers/Source/AccessTransformers/Public/AccessTransformersSubsystem.h
@@ -45,6 +45,22 @@ inline FString ToString(const FFunctionReference& FunctionReference) {
 }
 
 USTRUCT()
+struct ACCESSTRANSFORMERS_API FUStructReference {
+	GENERATED_BODY()
+
+	static FUStructReference FromConfigString(const FString& String);
+
+	UPROPERTY(Config)
+	FString Struct;
+
+	UStruct* Resolve(FString& OutError, FString& OutWarning) const;
+};
+
+inline FString ToString(const FUStructReference& StructReference) {
+	return StructReference.Struct;
+}
+
+USTRUCT()
 struct ACCESSTRANSFORMERS_API FPluginAccessTransformers {
 	GENERATED_BODY()
 
@@ -56,6 +72,9 @@ struct ACCESSTRANSFORMERS_API FPluginAccessTransformers {
 
 	UPROPERTY()
 	TArray<FPropertyReference> EditAnywhere;
+
+	UPROPERTY()
+	TArray<FUStructReference> BlueprintType;
 };
 
 UCLASS()
@@ -83,6 +102,8 @@ private:
 	TMap<FProperty*, EPropertyFlags> OriginalPropertyFlags;
 
 	TMap<UFunction*, EFunctionFlags> OriginalFunctionFlags;
+
+	TMap<UStruct*, FString> OriginalStructMetadata;
 	
 	IDirectoryWatcher::FDirectoryChanged OnAccessTransformersChanged;
 };


### PR DESCRIPTION
It didn't look like there were any other struct specifiers we'd want to use, so I went with a solution that just uses BlueprintType https://dev.epicgames.com/documentation/en-us/unreal-engine/struct-specifiers?application_version=4.27 .

I had to use `FUStructReference ` instead of `FStructReference ` because `FStructReference ` already exists in UE code.