### PR TITLE
Fix crash when switching between string session settings

### DIFF
--- a/Mods/SML/Source/SML/Public/Settings/StringValueSelector.h
+++ b/Mods/SML/Source/SML/Public/Settings/StringValueSelector.h
@@ -16,6 +16,8 @@ public:
 
 	virtual FVariant GetDefaultValue() const override { return Default; }
 
+	virtual bool ShouldFocusOptionSlotToEdit() const { return true; }
+
 	virtual TSubclassOf<class UFGOptionsValueController> GetValueSelectorWidgetClass() const override;
 
 #if WITH_EDITOR

--- a/Mods/SML/Source/SML/Public/Settings/StringValueSelector.h
+++ b/Mods/SML/Source/SML/Public/Settings/StringValueSelector.h
@@ -16,7 +16,7 @@ public:
 
 	virtual FVariant GetDefaultValue() const override { return Default; }
 
-	virtual bool ShouldFocusOptionSlotToEdit() const { return true; }
+	virtual bool ShouldFocusOptionSlotToEdit() const override { return true; }
 
 	virtual TSubclassOf<class UFGOptionsValueController> GetValueSelectorWidgetClass() const override;
 


### PR DESCRIPTION
Fix for 
![image](https://github.com/user-attachments/assets/12b03a14-f036-4d9f-855d-8337f054a04c)

Happens when rapidly switching between two or more different string session options

it seems 1.1 header introduced this new method that must be overwritten in child classes
```cpp
	virtual bool ShouldFocusOptionSlotToEdit() const
	{
		checkNoEntry();
		return false;
	}
```

Thanks to @mklierman for finding the solution