### PR TITLE
Update BlueprintSCSHooks to fix clearing data

### DIFF
--- a/Mods/SML/Source/SML/Public/Module/GameInstanceModule.h
+++ b/Mods/SML/Source/SML/Public/Module/GameInstanceModule.h
@@ -6,6 +6,7 @@
 #include "FGRemoteCallObject.h"
 #include "GameplayTagContainer.h"
 #include "Registry/RemoteCallObjectRegistry.h"
+#include "Patching/DeprecatedLegacyHookingTypes.h"
 #include "GameInstanceModule.generated.h"
 
 class UHookBlueprintGeneratedClass;
@@ -71,9 +72,9 @@ public:
     Make sure to call super on the C++ side if you have both a C++ and Blueprint implementation. */
     virtual void DispatchLifecycleEvent(ELifecyclePhase Phase) override;
 private:
-	/** DEPRECATED - to be removed. Only exists to make the migration to new Actor Mixins easier. */
-	UPROPERTY(Instanced, VisibleDefaultsOnly, Category = "Deprecated")
-	TArray<class UObject*> BlueprintSCSHooks;
+    /** DEPRECATED - to be removed. Only exists to make the migration to new Actor Mixins easier. */
+    UPROPERTY(Instanced, VisibleDefaultsOnly, Category = "Deprecated")
+    TArray<UBlueprintSCSHookData*> BlueprintSCSHooks;
 protected:
     /** Allow SetOwnerModReference access to game instance module manager */
     friend class UGameInstanceModuleManager;

--- a/Mods/SML/Source/SML/Public/Patching/DeprecatedLegacyHookingTypes.h
+++ b/Mods/SML/Source/SML/Public/Patching/DeprecatedLegacyHookingTypes.h
@@ -4,36 +4,38 @@
 #include "Engine/DataAsset.h"
 #include "DeprecatedLegacyHookingTypes.generated.h"
 
-UCLASS(Deprecated)
-class UDEPRECATED_BlueprintSCSHookData : public UDataAsset {
+/** DEPRECATED - to be removed. Only exists to make the migration to new Actor Mixins easier. */
+UCLASS()
+class UBlueprintSCSHookData : public UDataAsset {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere, Category = "Default")
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default")
 	TSubclassOf<class UActorComponent> ActorComponentClass;
 
-	UPROPERTY(EditAnywhere, Category = "Default")
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default")
 	FName VariableName;
 
-	UPROPERTY(VisibleAnywhere, Category = "Default", meta = (ShowInnerProperties))
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default", meta = (ShowInnerProperties))
 	UActorComponent* ActorComponentTemplate;
 
-	UPROPERTY(EditAnywhere, Category = "Default")
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default")
 	FName AttachToName;
 
-	UPROPERTY(Instanced, VisibleAnywhere, Category = "Default")
+	UPROPERTY(Instanced, VisibleDefaultsOnly, Category = "Default")
 	TArray<UObject*> Children;
 };
 
-UCLASS(Deprecated)
-class UDEPRECATED_RootBlueprintSCSHookData : public UDEPRECATED_BlueprintSCSHookData {
+/** DEPRECATED - to be removed. Only exists to make the migration to new Actor Mixins easier. */
+UCLASS()
+class URootBlueprintSCSHookData : public UBlueprintSCSHookData {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere, Category = "Default", meta = (MultiLine = "true"))
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default", meta = (MultiLine = "true"))
 	FString DeveloperComment;
 
-	UPROPERTY(EditAnywhere, Category = "Default")
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default")
 	TSoftClassPtr<class AActor> ActorClass;
 
-	UPROPERTY(EditAnywhere, Category = "Default")
+	UPROPERTY(VisibleDefaultsOnly, Category = "Default")
 	FName ParentComponentName;
 };


### PR DESCRIPTION
Blueprint SCS hooks were clearing existing data. The property needed to use the UBlueprintSCSHookData class to maintain existing data.

UE doesn't allow a property to use a deprecated class despite the error message saying you just have to mark it deprecated. The only way I could actually get it to compile was with [[deprecated("This property uses a deprecated class.")]] which is a standard cpp thing, but doing so prevents the property from showing in the editor.

In order to have it visible in the editor and compile I had to remove the Deprecated specifier from the BlueprintSCSHookData classes. Then, to make it so values could not be changed I had to make them all VisibleDefaultsOnly.