### PR TITLE
Refactor AlpakitModEntryList and add Sort Options

### DIFF
--- a/Mods/Alpakit/Source/Alpakit/Private/AlpakitModEntryList.cpp
+++ b/Mods/Alpakit/Source/Alpakit/Private/AlpakitModEntryList.cpp
@@ -7,123 +7,225 @@
 
 #define LOCTEXT_NAMESPACE "AlpakitModListEntry"
 
+/**
+ * Main entry point for constructing the mod list widget.
+ * Sets up the overall layout with a top bar containing filters and a scrollable mod list below.
+ */
 void SAlpakitModEntryList::Construct(const FArguments& Args) {
-
 	ChildSlot[
-	SNew(SVerticalBox)
-		+SVerticalBox::Slot().AutoHeight().Padding(0, 5)[
-			SNew(SHorizontalBox)
-			+SHorizontalBox::Slot().FillWidth(1).VAlign(VAlign_Center)[
-				SNew(SVerticalBox)
-				+SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 5)[
-					Args._BarSlot.Widget
-				]
-				+SVerticalBox::Slot()[
-					SNew(SHorizontalBox)
-					+SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0)[
-						SAssignNew(AllModsCheckbox, SCheckBox)
-						.ToolTipText(LOCTEXT("AllModsCheckboxAlpakit_Tooltip", "Select/deselect all displayed mods. Search can be used to narrow down which are affected"))
-						.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
-							SetAllMods(InState == ECheckBoxState::Checked);
-						})
-					]
-					+SHorizontalBox::Slot().FillWidth(1).VAlign(VAlign_Center).Padding(0, 0, 10, 0)[
-						SNew(SEditableTextBox)
-						.ToolTipText(LOCTEXT("SearchHint_Tooltip", "Filter the list based on the text entered here. Friendly name and Mod Reference supported"))
-						.HintText(LOCTEXT("SearchHint", "Search Mod..."))
-						.OnTextChanged_Lambda([this](const FText& InText) {
-							this->Filter(InText.ToString());
-						})
-					]
-					+SHorizontalBox::Slot().AutoWidth()[
-						SNew(SCheckBox)
-						.Content()[
-							SNew(STextBlock)
-							.ToolTipText(LOCTEXT("ShowEnginePlugins_Tooltip", "Display all Unreal Engine plugins loaded at the engine level (notably not mods, you usually don't need this enabled)"))
-							.Text(LOCTEXT("ShowEnginePlugins", "Show Engine Plugins"))
-						]
-						.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
-							this->SetShowEngine(InState == ECheckBoxState::Checked);
-						})
-					]
-					+SHorizontalBox::Slot().AutoWidth()[
-						SNew(SSpacer)
-						.Size(FVector2D(10.0f, 10.0f))
-					]
-					+SHorizontalBox::Slot().AutoWidth()[
-						SNew(SCheckBox)
-						.Content()[
-							SNew(STextBlock)
-							.ToolTipText(LOCTEXT("ShowProjectPlugins_Tooltip", "Display all Unreal Engine plugins loaded at the project level (such as Plugins folder mods, you usually don't need this enabled)"))
-							.Text(LOCTEXT("ShowProjectPlugins", "Show Project Plugins"))
-						]
-						.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
-							this->SetShowProject(InState == ECheckBoxState::Checked);
-						})
-					]
-				]
-			]
-			+SHorizontalBox::Slot().AutoWidth()
-			[
-				Args._SearchTrail.Widget
-			]
+		SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 5)[
+			CreateTopBar(Args)
 		]
 		+ SVerticalBox::Slot().FillHeight(1.0f)[
-			SNew(SScrollBox)
-			.Orientation(Orient_Vertical)
-			.ScrollBarAlwaysVisible(true)
-			+ SScrollBox::Slot()[
-				SAssignNew(ModList, SListView<TSharedRef<IPlugin>>)
-				.SelectionMode(ESelectionMode::None)
-				.ListItemsSource(&FilteredMods)
-				.OnGenerateRow_Lambda(
-					[this, Args](TSharedRef<IPlugin> Mod, const TSharedRef<STableViewBase>& List) {
-						UAlpakitSettings* Settings = UAlpakitSettings::Get();
-						return SNew(STableRow<TSharedRef<IPlugin>>, List)
-							.Style(&FAppStyle::Get().GetWidgetStyle<FTableRowStyle>("TableView.AlternatingRow"))
-							[
-								SNew(SAlpakitModEntry, Mod, SharedThis(this))
-								.Lead()[
-									SNew(SHorizontalBox)
-									+SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0)
-									[
-										SNew(SCheckBox)
-											.ToolTipText(LOCTEXT("AlpakitModEntryEnabled_Tooltip", "If enabled, this mod will be packaged when the 'Alpakit Dev' or 'Alpakit Release' buttons are pressed"))
-											.OnCheckStateChanged_Lambda([this, Mod](ECheckBoxState CheckBoxState){
-												OnCheckboxChanged(Mod, CheckBoxState);
-											})
-											.IsChecked_Lambda([Settings, Mod] { return Settings->ModSelection.FindOrAdd(Mod->GetName(), false) ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; })
-									]
-									+SHorizontalBox::Slot().AutoWidth()
-									[
-										Args._ModEntryLead.IsBound() ? Args._ModEntryLead.Execute(Mod) : SNullWidget::NullWidget
-									]
-									+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0).VAlign(VAlign_Center)[
-										SNew(SButton)
-										.Text(LOCTEXT("EditModAlpakit", "Edit"))
-										.OnClicked_Lambda([this, Mod] {
-											const TSharedRef<SAlpakitEditModDialog> EditModDialog = SNew(SAlpakitEditModDialog, Mod);
-											FSlateApplication::Get().AddModalWindow(EditModDialog, SharedThis(this));
-											return FReply::Handled();
-										})
-										.ToolTipText_Lambda([Mod]{
-											return FText::Format(LOCTEXT("EditModAlpakit_tooltip", "Edit {0} via the wizard"), FText::FromString(Mod->GetName()));
-										})
-									]
-								]
-								.Trail()
-								[
-									Args._ModEntryTrail.IsBound() ? Args._ModEntryTrail.Execute(Mod) : SNullWidget::NullWidget
-								]
-						];
-					})
-			]
+			CreateModList(Args)
 		]
 	];
 
+	UpdateSortOptions();
 	LoadMods();
 	UpdateAllCheckbox();
 	IPluginManager::Get().OnNewPluginCreated().AddSP(this, &SAlpakitModEntryList::OnNewPluginCreated);
+}
+
+/**
+ * Creates the top bar containing the main controls and search functionality.
+ * The top bar is split into two rows:
+ * - Top row: Sort By and Filter checkboxes
+ * - Bottom row: Select all checkbox and search box
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateTopBar(const FArguments& Args) {
+	return SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot().FillWidth(1).VAlign(VAlign_Center)[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 5)[
+				Args._BarSlot.Widget
+			]
+			+ SVerticalBox::Slot()[
+				CreateSearchAndFilters()
+			]
+		]
+		+ SHorizontalBox::Slot().AutoWidth()[
+			Args._SearchTrail.Widget
+		];
+}
+
+/**
+ * Creates the search and filter controls arranged in two rows:
+ * - Top row: Search By and Engine/Project plugin filters
+ * - Bottom row: Select all checkbox and search box
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateSearchAndFilters() {
+	return SNew(SVerticalBox)
+		+ SVerticalBox::Slot().AutoHeight().Padding(0, 0, 0, 5)[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth()[
+				CreateSortByComboBox()
+			]
+			+ SHorizontalBox::Slot().AutoWidth()[
+				SNew(SSpacer)
+				.Size(FVector2D(10.0f, 10.0f))
+			]
+			+ SHorizontalBox::Slot().AutoWidth()[
+				CreateEnginePluginsCheckbox()
+			]
+			+ SHorizontalBox::Slot().AutoWidth()[
+				SNew(SSpacer)
+				.Size(FVector2D(10.0f, 10.0f))
+			]
+			+ SHorizontalBox::Slot().AutoWidth()[
+				CreateProjectPluginsCheckbox()
+			]
+		]
+		+ SVerticalBox::Slot().AutoHeight()[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0)[
+				SAssignNew(AllModsCheckbox, SCheckBox)
+				.ToolTipText(LOCTEXT("AllModsCheckboxAlpakit_Tooltip", "Select/deselect all displayed mods. Search can be used to narrow down which are affected"))
+				.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
+					SetAllMods(InState == ECheckBoxState::Checked);
+				})
+			]
+			+ SHorizontalBox::Slot().FillWidth(1).VAlign(VAlign_Center)[
+				SNew(SEditableTextBox)
+				.ToolTipText(LOCTEXT("SearchHint_Tooltip", "Filter the list based on the text entered here. Friendly name and Mod Reference supported"))
+				.HintText(LOCTEXT("SearchHint", "Search Mod..."))
+				.OnTextChanged_Lambda([this](const FText& InText) {
+					this->Filter(InText.ToString());
+				})
+			]
+		];
+}
+
+/**
+ * Creates the checkbox for toggling visibility of engine plugins.
+ * Engine plugins are typically not mods, so this is usually disabled.
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateEnginePluginsCheckbox() {
+	return SNew(SCheckBox)
+		.Content()[
+			SNew(STextBlock)
+			.ToolTipText(LOCTEXT("ShowEnginePlugins_Tooltip", "Display all Unreal Engine plugins loaded at the engine level (notably not mods, you usually don't need this enabled)"))
+			.Text(LOCTEXT("ShowEnginePlugins", "Show Engine Plugins"))
+		]
+		.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
+			this->SetShowEngine(InState == ECheckBoxState::Checked);
+		});
+}
+
+/**
+ * Creates the checkbox for toggling visibility of project plugins.
+ * Project plugins are typically not mods, so this is usually disabled.
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateProjectPluginsCheckbox() {
+	return SNew(SCheckBox)
+		.Content()[
+			SNew(STextBlock)
+			.ToolTipText(LOCTEXT("ShowProjectPlugins_Tooltip", "Display all Unreal Engine plugins loaded at the project level (such as Plugins folder mods, you usually don't need this enabled)"))
+			.Text(LOCTEXT("ShowProjectPlugins", "Show Project Plugins"))
+		]
+		.OnCheckStateChanged_Lambda([this](ECheckBoxState InState) {
+			this->SetShowProject(InState == ECheckBoxState::Checked);
+		});
+}
+
+/**
+ * Creates the sort options dropdown that allows sorting by either Mod Reference or Friendly Name.
+ * The current selection is persisted in the settings.
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateSortByComboBox() {
+	return SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot().AutoWidth()[
+			SNew(STextBlock)
+			.Text(LOCTEXT("SortByLabel", "Sort By:"))
+			.Margin(FMargin(0, 2, 5, 0))
+		]
+		+ SHorizontalBox::Slot().AutoWidth()[
+			SNew(SComboBox<TSharedPtr<FText>>)
+			.OptionsSource(&SortOptions)
+			.OnSelectionChanged_Lambda([this](TSharedPtr<FText> NewSelection, ESelectInfo::Type) {
+				CurrentSortOption = NewSelection;
+				this->SetOrderByFriendlyName(NewSelection->ToString() == TEXT("Friendly Name"));
+			})
+			.OnGenerateWidget_Lambda([](TSharedPtr<FText> InOption) {
+				return SNew(STextBlock).Text(*InOption);
+			})
+			[
+				SNew(STextBlock)
+				.Text_Lambda([this]() {
+					return *CurrentSortOption;
+				})
+			]
+		];
+}
+
+/**
+ * Creates the scrollable list of mods.
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateModList(const FArguments& Args) {
+	return SNew(SScrollBox)
+		.Orientation(Orient_Vertical)
+		.ScrollBarAlwaysVisible(true)
+		+ SScrollBox::Slot()[
+			SAssignNew(ModList, SListView<TSharedRef<IPlugin>>)
+			.SelectionMode(ESelectionMode::None)
+			.ListItemsSource(&FilteredMods)
+			.OnGenerateRow_Lambda([this, Args](TSharedRef<IPlugin> Mod, const TSharedRef<STableViewBase>& List) {
+				return CreateModListRow(Mod, List, Args);
+			})
+		];
+}
+
+/**
+ * Creates a single row in the mod list.
+ */
+TSharedRef<ITableRow> SAlpakitModEntryList::CreateModListRow(TSharedRef<IPlugin> Mod, const TSharedRef<STableViewBase>& List, const FArguments& Args) {
+	UAlpakitSettings* Settings = UAlpakitSettings::Get();
+	return SNew(STableRow<TSharedRef<IPlugin>>, List)
+		.Style(&FAppStyle::Get().GetWidgetStyle<FTableRowStyle>("TableView.AlternatingRow"))
+		[
+			SNew(SAlpakitModEntry, Mod, SharedThis(this))
+			.Lead()[
+				CreateModEntryLead(Mod, Args)
+			]
+			.Trail()[
+				Args._ModEntryTrail.IsBound() ? Args._ModEntryTrail.Execute(Mod) : SNullWidget::NullWidget
+			]
+		];
+}
+
+/**
+ * Creates the lead section of a mod entry row.
+ * Contains a checkbox for selection, Alpakit button, and an edit button.
+ */
+TSharedRef<SWidget> SAlpakitModEntryList::CreateModEntryLead(TSharedRef<IPlugin> Mod, const FArguments& Args) {
+	UAlpakitSettings* Settings = UAlpakitSettings::Get();
+	return SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0)[
+			SNew(SCheckBox)
+			.ToolTipText(LOCTEXT("AlpakitModEntryEnabled_Tooltip", "If enabled, this mod will be packaged when the 'Alpakit Dev' or 'Alpakit Release' buttons are pressed"))
+			.OnCheckStateChanged_Lambda([this, Mod](ECheckBoxState CheckBoxState) {
+				OnCheckboxChanged(Mod, CheckBoxState);
+			})
+			.IsChecked_Lambda([Settings, Mod] { 
+				return Settings->ModSelection.FindOrAdd(Mod->GetName(), false) ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; 
+			})
+		]
+		+ SHorizontalBox::Slot().AutoWidth()[
+			Args._ModEntryLead.IsBound() ? Args._ModEntryLead.Execute(Mod) : SNullWidget::NullWidget
+		]
+		+ SHorizontalBox::Slot().AutoWidth().Padding(0, 0, 5, 0).VAlign(VAlign_Center)[
+			SNew(SButton)
+			.Text(LOCTEXT("EditModAlpakit", "Edit"))
+			.OnClicked_Lambda([this, Mod] {
+				const TSharedRef<SAlpakitEditModDialog> EditModDialog = SNew(SAlpakitEditModDialog, Mod);
+				FSlateApplication::Get().AddModalWindow(EditModDialog, SharedThis(this));
+				return FReply::Handled();
+			})
+			.ToolTipText_Lambda([Mod] {
+				return FText::Format(LOCTEXT("EditModAlpakit_tooltip", "Edit {0} via the wizard"), FText::FromString(Mod->GetName()));
+			})
+		];
 }
 
 bool DoesPluginHaveRuntime(const IPlugin& Plugin) {
@@ -147,11 +249,11 @@ bool DoesPluginHaveRuntime(const IPlugin& Plugin) {
 }
 
 static bool IsPluginEditorOnly(const IPlugin& Plugin) {
-    if (TSharedPtr<FJsonObject> Json = Plugin.GetDescriptor().CachedJson) {
-        bool Result = false;
-        return Json->TryGetBoolField("EditorOnly", Result) && Result;
-    }
-    return false;
+	if (TSharedPtr<FJsonObject> Json = Plugin.GetDescriptor().CachedJson) {
+		bool Result = false;
+		return Json->TryGetBoolField("EditorOnly", Result) && Result;
+	}
+	return false;
 }
 
 void SAlpakitModEntryList::LoadMods() {
@@ -172,8 +274,12 @@ void SAlpakitModEntryList::LoadMods() {
 			}
 		}
 	}
-	Mods.Sort([](const TSharedRef<IPlugin> Plugin1, const TSharedRef<IPlugin> Plugin2) {
-		return Plugin1->GetName() < Plugin2->GetName();
+
+	Mods.Sort([this](const TSharedRef<IPlugin> Plugin1, const TSharedRef<IPlugin> Plugin2) {
+		if (bOrderByFriendlyName)
+			return Plugin1->GetFriendlyName() < Plugin2->GetFriendlyName();
+		else
+			return Plugin1->GetName() < Plugin2->GetName();
 	});
 	Filter(LastFilter);
 }
@@ -229,6 +335,16 @@ void SAlpakitModEntryList::SetShowEngine(bool bInShowEngine) {
 void SAlpakitModEntryList::SetShowProject(bool bInShowProject) {
 	bShowProject = bInShowProject;
 	LoadMods();
+}
+
+void SAlpakitModEntryList::SetOrderByFriendlyName(bool bInOrderByFriendlyName)
+{
+	bOrderByFriendlyName = bInOrderByFriendlyName;
+	LoadMods();
+
+	UAlpakitSettings* Settings = UAlpakitSettings::Get();
+	Settings->OrderByFriendlyName = bInOrderByFriendlyName;
+	Settings->SaveSettings();
 }
 
 void SAlpakitModEntryList::OnNewPluginCreated(IPlugin& Plugin)
@@ -287,6 +403,20 @@ void SAlpakitModEntryList::UpdateAllCheckbox() {
 		AllModsCheckbox->SetIsChecked(ECheckBoxState::Checked);
 	else if (allFalse)
 		AllModsCheckbox->SetIsChecked(ECheckBoxState::Unchecked);
+
+}
+
+void SAlpakitModEntryList::UpdateSortOptions()
+{
+	SortOptions.Add(MakeShared<FText>(LOCTEXT("ModReference", "Mod Reference")));
+	SortOptions.Add(MakeShared<FText>(LOCTEXT("FriendlyName", "Friendly Name")));
+	CurrentSortOption = SortOptions[0]; // Default selection
+
+	UAlpakitSettings* Settings = UAlpakitSettings::Get();
+	bOrderByFriendlyName = Settings->OrderByFriendlyName;
+
+	if (bOrderByFriendlyName)
+		CurrentSortOption = SortOptions[1];
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Mods/Alpakit/Source/Alpakit/Public/AlpakitModEntryList.h
+++ b/Mods/Alpakit/Source/Alpakit/Public/AlpakitModEntryList.h
@@ -38,14 +38,28 @@ class SAlpakitModEntryList : public SCompoundWidget {
 	void SetShowEngine(bool bInShowEngine);
 	void SetShowProject(bool bInShowProject);
 
+	void SetOrderByFriendlyName(bool bInOrderByFriendlyName);
+
 	TArray<TSharedRef<IPlugin>> GetFilteredMods() const { return FilteredMods; }
 
 	void OnCheckboxChanged(TSharedRef<IPlugin> Mod, ECheckBoxState NewState);
 	void UpdateAllCheckbox();
+	void UpdateSortOptions();
 
 	void OnNewPluginCreated(IPlugin& Plugin);
 	void SetAllMods(bool Checked);
+
 private:
+	// UI Component Creation Functions
+	TSharedRef<SWidget> CreateTopBar(const FArguments& Args);
+	TSharedRef<SWidget> CreateSearchAndFilters();
+	TSharedRef<SWidget> CreateEnginePluginsCheckbox();
+	TSharedRef<SWidget> CreateProjectPluginsCheckbox();
+	TSharedRef<SWidget> CreateSortByComboBox();
+	TSharedRef<SWidget> CreateModList(const FArguments& Args);
+	TSharedRef<ITableRow> CreateModListRow(TSharedRef<IPlugin> Mod, const TSharedRef<STableViewBase>& List, const FArguments& Args);
+	TSharedRef<SWidget> CreateModEntryLead(TSharedRef<IPlugin> Mod, const FArguments& Args);
+
 	TSharedPtr<SListView<TSharedRef<IPlugin>>> ModList;
 	TSharedPtr<SCheckBox> AllModsCheckbox;
 	TArray<TSharedRef<IPlugin>> Mods;
@@ -53,4 +67,7 @@ private:
 	FString LastFilter;
 	bool bShowEngine = false;
 	bool bShowProject = false;
+	bool bOrderByFriendlyName = false;
+	TArray<TSharedPtr<FText>> SortOptions;
+	TSharedPtr<FText> CurrentSortOption;
 };

--- a/Mods/Alpakit/Source/Alpakit/Public/AlpakitSettings.h
+++ b/Mods/Alpakit/Source/Alpakit/Public/AlpakitSettings.h
@@ -74,6 +74,9 @@ public:
     UPROPERTY(BlueprintReadOnly, config, Category = Config)
     TMap<FString, bool> ModSelection;
 
+    UPROPERTY(BlueprintReadOnly, config, Category = Config)
+    bool OrderByFriendlyName;
+
 	UFUNCTION()
 	TArray<FString> GetAllowedBuildConfigurations() const;
 


### PR DESCRIPTION
Refactor of the AlpakitModEntryList Slate code to make it modular and more readable.

Added a Combo Box for sorting by Friendly Name or Mod Reference. The selected value is saved/loaded automatically.