### PR TITLE
Re-add keywords to WidgetBlueprintHookData class

### DIFF
--- a/Mods/SML/Source/SML/Public/Patching/WidgetBlueprintHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/WidgetBlueprintHookManager.h
@@ -104,7 +104,7 @@ public:
 };
 
 /** Data required to hook into the existing widget blueprint */
-UCLASS()
+UCLASS(NotBlueprintable, BlueprintType, EditInlineNew)
 class SML_API UWidgetBlueprintHookData : public UDataAsset {
 	GENERATED_BODY()
 public:


### PR DESCRIPTION
Re-add NotBlueprintable, BlueprintType, EditInlineNew to WidgetBlueprintHookData class definition

See https://discord.com/channels/555424930502541343/1377266537211105400/1377267644146647110