### PR TITLE
Fixed the wait for subsystem method

### DIFF
--- a/Mods/SML/Source/SML/Private/Subsystem/SubsystemActorManager.cpp
+++ b/Mods/SML/Source/SML/Private/Subsystem/SubsystemActorManager.cpp
@@ -93,7 +93,7 @@ void USubsystemActorManager::RegisterSubsystemActor(TSubclassOf<AModSubsystem> S
 	}
 }
 
-void USubsystemActorManager::WaitForSubsystem(TSubclassOf<AModSubsystem> SubsystemClass, FLatentActionInfo& LatentInfo) {
+void USubsystemActorManager::WaitForSubsystem(TSubclassOf<AModSubsystem> SubsystemClass, FLatentActionInfo LatentInfo) {
 	checkf(SubsystemClass, TEXT("Attempt to WaitForSubsystem on NULL SubsystemClass"));
 	checkf(RegisteredSubsystems.Contains(SubsystemClass), TEXT("Attempt to WaitForSubsystem on Unregistered SubsystemClass '%s'"), *SubsystemClass->GetPathName());
 

--- a/Mods/SML/Source/SML/Public/Subsystem/SubsystemActorManager.h
+++ b/Mods/SML/Source/SML/Public/Subsystem/SubsystemActorManager.h
@@ -36,7 +36,7 @@ public:
 
 	/** Waits until provided Modded SubsystemClass is Available and can be retrieved through GetSubsystemActor */
 	UFUNCTION(BlueprintCallable, meta = (Latent, LatentInfo = "LatentInfo"))
-	void WaitForSubsystem(TSubclassOf<AModSubsystem> SubsystemClass, struct FLatentActionInfo& LatentInfo);
+	void WaitForSubsystem(TSubclassOf<AModSubsystem> SubsystemClass, struct FLatentActionInfo LatentInfo);
 	
 	/** Retrieves subsystem actor of the provided class, or NULL if it has not been created or replicated yet */
 	UFUNCTION(BlueprintPure, meta = (DisplayName = "GetSubsystemActor", DeterminesOutputType = "SubsystemClass"))


### PR DESCRIPTION
A fix for a missing pin error
![image](https://github.com/user-attachments/assets/749601a4-55ff-4c9c-9938-393bfe8459bd)
![image](https://github.com/user-attachments/assets/26622cb4-4b98-4fe7-a71e-2baa6499f5ed)

I looked at other methods that used `FLatentActionInfo` and noticed most of them dont use the `&`, so i removed it and now it works. however this method signature was not changed for 4 years so.. so maybe this method is not all that important to have?

I tested its functional behaviour by setting it up my world module's construction phase
![image](https://github.com/user-attachments/assets/f4ad84a5-9cfe-4e74-814f-9cfef2a5d49a)
```console
[2025.05.29-14.47.12:642][ 71]LogArchipelago: Display: [/Archipelago/RootGameWorld_Archipelago]: WaitForSubsystem: Waiting for Replicated subsystem
[2025.05.29-14.47.12:642][ 71]LogApGameWorldModule: Display: UApGameWorldModule()::DispatchLifecycleEvent(ELifecyclePhase::CONSTRUCTION)
....
[2025.05.29-14.47.41:440][ 71]LogApGameWorldModule: Display: UApGameWorldModule()::DispatchLifecycleEvent(ELifecyclePhase::POST_INITIALIZATION)
[2025.05.29-14.47.41:570][ 71]LogArchipelago: Display: [/Archipelago/RootGameWorld_Archipelago]: WaitForSubsystem: Subsystem Retreiveable
[2025.05.29-14.47.41:570][ 71]LogArchipelago: Warning: [/Archipelago/RootGameWorld_Archipelago]: WaitForSubsystem: Subsystem is valid
```