### PR TITLE
Native hooking improvements

### DIFF
--- a/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
+++ b/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
@@ -2,6 +2,7 @@
 #include "CoreMinimal.h"
 #include "funchook.h"
 #include "AssemblyAnalyzer.h"
+#include "HAL/PlatformMemory.h"
 
 DEFINE_LOG_CATEGORY(LogNativeHookManager);
 
@@ -19,6 +20,8 @@ namespace
 //to keep single hook instance for each method
 static TMap<void*, void*> HandlerListMap;
 static TMap<const void* /* RealFunctionAddress */, FStandardHook> StandardHookMap;
+static TMap<void** /* VtableEntry */, void* /* OriginalFunction */> VtableHookMap;
+static TMap<UFunction*, FNativeFuncPtr /* OriginalFunction */> UFunctionHookMap;
 
 void* FNativeHookManagerInternal::GetHandlerListInternal(const void* Key)
 {
@@ -43,6 +46,49 @@ void FNativeHookManagerInternal::SetHandlerListInstanceInternal(void* Key, void*
 
 static void LogDebugAssemblyAnalyzer(const ANSICHAR* Message) {
 	UE_LOG(LogNativeHookManager, Display, TEXT("AssemblyAnalyzer Debug: %hs"), Message);
+}
+
+static FunctionInfo DiscoverMemberFunction(const FString& DebugSymbolName, FMemberFunctionPointer& MemberFunctionPointer) {
+	SetDebugLoggingHook(&LogDebugAssemblyAnalyzer);
+
+#ifndef _WIN64
+	// On Linux, MemberFunctionPointer.FunctionAddress will not be a valid pointer if the method is virtual.
+	// See ConvertFunctionPointer for more info.
+	if (MemberFunctionPointer.FunctionAddress == nullptr) {
+		return {
+			.bIsValid = true,
+			.bIsVirtualFunction = true,
+			.RealFunctionAddress = nullptr,
+			.VirtualTableFunctionOffset = MemberFunctionPointer.VtableDisplacement,
+		};
+	}
+#endif
+
+	// We should now always have a valid FunctionAddress in MemberFunctionPointer:
+	//   * On Windows, all functions (virtual and non-virtual) have a valid address.
+	//   * On Linux, only virtual functions don't and they have already been handled above.
+
+	UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to discover %s at %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+	FunctionInfo FunctionInfo = DiscoverFunction((uint8*)MemberFunctionPointer.FunctionAddress);
+	checkf(FunctionInfo.bIsValid, TEXT("Attempt to hook invalid function %s: Provided code pointer %p is not valid"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+
+#ifdef _WIN64
+	// We assign the vtable offset from the FunctionInfo struct whether we found a vtable offset or not. If the
+	// method isn't virtual, this value isn't used.
+	MemberFunctionPointer.VtableDisplacement = FunctionInfo.VirtualTableFunctionOffset;
+#else
+	// Just in case DiscoverFunction identifies a non-virtual function as a vtable thunk...
+	FunctionInfo.bIsVirtualFunction = false;
+#endif
+
+	return FunctionInfo;
+}
+
+static void** GetVtableEntry(const FMemberFunctionPointer& MemberFunctionPointer, const void* SampleObjectInstance) {
+	// Target Function Address = (this + ThisAdjustment)->vftable[VirtualFunctionOffset]
+	void* AdjustedThisPointer = (uint8*)SampleObjectInstance + MemberFunctionPointer.ThisAdjustment;
+	void* VirtualFunctionTableBase = *(void**)AdjustedThisPointer;
+	return (void**)((uint8*)VirtualFunctionTableBase + MemberFunctionPointer.VtableDisplacement);
 }
 
 // Installs a hook a the original function. Returns true if a new hook is installed or false on error or
@@ -79,42 +125,15 @@ void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbo
 }
 
 void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction) {
-	SetDebugLoggingHook(&LogDebugAssemblyAnalyzer);
+	FunctionInfo FunctionInfo = DiscoverMemberFunction(DebugSymbolName, MemberFunctionPointer);
 
-#ifdef _WIN64
-	// On Windows, the OriginalFunctionPointer is a valid function pointer. We can simply check its info here.
-	UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to discover %s at %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
-	FunctionInfo FunctionInfo = DiscoverFunction((uint8 *)MemberFunctionPointer.FunctionAddress);
-	checkf(FunctionInfo.bIsValid, TEXT("Attempt to hook invalid function %s: Provided code pointer %p is not valid"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
-
-	// We assign the vtable offset from the FunctionInfo struct whether we found a vtable offset or not. If the
-	// method isn't virtual, this value isn't used.
-	MemberFunctionPointer.VtableDisplacement = FunctionInfo.VirtualTableFunctionOffset;
-	bool isVirtual = FunctionInfo.bIsVirtualFunction;
-#else
-	// On Linux, MemberFunctionPointer.FunctionAddress will not be a valid pointer if the method is virtual. See ConvertFunctionPointer
-	// for more info.
-	FunctionInfo FunctionInfo;
-
-	bool isVirtual = (MemberFunctionPointer.FunctionAddress == nullptr);
-
-	if (!isVirtual) {
-		FunctionInfo = DiscoverFunction((uint8*) MemberFunctionPointer.FunctionAddress);
-	}
-#endif
-
-	if (isVirtual) {
+	if (FunctionInfo.bIsVirtualFunction) {
 		// The patched call is virtual. Calculate the actual address of the function being called.
 		checkf(SampleObjectInstance, TEXT("Attempt to hook virtual function override without providing object instance for implementation resolution"));
 		UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to resolve virtual function %s. This adjustment: 0x%x, virtual function table offset: 0x%x"), *DebugSymbolName, MemberFunctionPointer.ThisAdjustment, MemberFunctionPointer.VtableDisplacement);
 
-		//Target Function Address = (this + ThisAdjustment)->vftable[VirtualFunctionOffset]
-		void* AdjustedThisPointer = ((uint8*) SampleObjectInstance) + MemberFunctionPointer.ThisAdjustment;
-		uint8** VirtualFunctionTableBase = *((uint8***) AdjustedThisPointer);
-		//Offset is in bytes from the start of the virtual table, we need to convert it to pointer array index
-		uint8* FunctionImplementationPointer = VirtualFunctionTableBase[MemberFunctionPointer.VtableDisplacement / 8];
-
-		FunctionInfo = DiscoverFunction(FunctionImplementationPointer);
+		void* FunctionImplementationPointer = *GetVtableEntry(MemberFunctionPointer, SampleObjectInstance);
+		FunctionInfo = DiscoverFunction((uint8*)FunctionImplementationPointer);
 
 		//Perform basic checking to make sure calculation was correct, or at least seems to be so
 		checkf(FunctionInfo.bIsValid, TEXT("Failed to resolve virtual function for thunk %s at %p, resulting address contains no executable code"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
@@ -142,4 +161,89 @@ void FNativeHookManagerInternal::UnregisterHookFunction(const FString& DebugSymb
 	CHECK_FUNCHOOK_ERR(funchook_uninstall(funchook, 0));
 	CHECK_FUNCHOOK_ERR(funchook_destroy(funchook));
 	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered hook for function %s at %p"), *DebugSymbolName, RealFunctionAddress);
+}
+
+static void SetVtableEntry(const FString& DebugSymbolName, void** VtableEntry, void* NewValue)
+{
+	// FPlatformMemory doesn't seem to have a way to get the old page protections back, but it's a good
+	// bet that it was a read-only page.
+
+	const size_t PageSize = FPlatformMemory::GetConstants().PageSize;
+	void* PageStart = AlignDown(VtableEntry, PageSize);
+
+	verifyf(FPlatformMemory::PageProtect(PageStart, PageSize, true, true),
+		TEXT("Failed to un-protect vtable entry for function %s at %p"), *DebugSymbolName, VtableEntry);
+
+	*VtableEntry = NewValue;
+
+	verifyf(FPlatformMemory::PageProtect(PageStart, PageSize, true, false),
+		TEXT("Failed to re-protect vtable entry for function %s at %p"), *DebugSymbolName, VtableEntry);
+}
+
+void** FNativeHookManagerInternal::RegisterVtableHook(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutOriginalFunction)
+{
+	const FunctionInfo FunctionInfo = DiscoverMemberFunction(DebugSymbolName, MemberFunctionPointer);
+	checkf(FunctionInfo.bIsVirtualFunction, TEXT("Attempt to hook non-virtual function %s"), *DebugSymbolName);
+	void** VtableEntry = GetVtableEntry(MemberFunctionPointer, SampleObjectInstance);
+	void*& MapOriginalFunction = VtableHookMap.FindOrAdd(VtableEntry);
+
+	if (MapOriginalFunction == nullptr)
+	{
+		MapOriginalFunction = *VtableEntry;
+		SetVtableEntry(DebugSymbolName, VtableEntry, HookFunctionPointer);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked vtable entry for %s at %p"), *DebugSymbolName, VtableEntry);
+	}
+
+	*OutOriginalFunction = MapOriginalFunction;
+	return VtableEntry;
+}
+
+void FNativeHookManagerInternal::UnregisterVtableHook(const FString& DebugSymbolName, void** VtableEntry)
+{
+	void* OriginalFunction;
+
+	if (!VtableHookMap.RemoveAndCopyValue(VtableEntry, OriginalFunction))
+	{
+		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister vtable hook for %s at %p which was not registered"), *DebugSymbolName, VtableEntry);
+		return;
+	}
+
+	SetVtableEntry(DebugSymbolName, VtableEntry, OriginalFunction);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered vtable hook for %s at %p"), *DebugSymbolName, VtableEntry);
+}
+
+UFunction* FNativeHookManagerInternal::RegisterUFunctionHook(UClass* Class, FName FunctionName, FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction)
+{
+	TStringBuilder<1024> DebugSymbolName;
+	Class->GetFName().AppendString(DebugSymbolName);
+	DebugSymbolName << TEXT("::");
+	FunctionName.AppendString(DebugSymbolName);
+
+	UFunction* Function = Class->FindFunctionByName(FunctionName);
+	checkf(Function, TEXT("Failed to find UFunction %s"), *DebugSymbolName);
+	FNativeFuncPtr& MapOriginalFunction = UFunctionHookMap.FindOrAdd(Function);
+
+	if (MapOriginalFunction == nullptr)
+	{
+		MapOriginalFunction = Function->GetNativeFunc();
+		Function->SetNativeFunc(HookFunctionPointer);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked UFunction %s (%p)"), *DebugSymbolName, Function);
+	}
+
+	*OutOriginalFunction = MapOriginalFunction;
+	return Function;
+}
+
+void FNativeHookManagerInternal::UnregisterUFunctionHook(const FString& DebugSymbolName, UFunction* Function)
+{
+	FNativeFuncPtr OriginalFunction;
+
+	if (!UFunctionHookMap.RemoveAndCopyValue(Function, OriginalFunction))
+	{
+		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister UFunction hook for %s which is not registered"), *DebugSymbolName);
+		return;
+	}
+
+	Function->SetNativeFunc(OriginalFunction);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered UFunction hook %s"), *DebugSymbolName);
 }

--- a/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
+++ b/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
@@ -42,13 +42,13 @@ void FNativeHookManagerInternal::SetHandlerListInstanceInternal(void* Key, void*
 }
 
 #define CHECK_FUNCHOOK_ERR(arg) \
-	if (arg != FUNCHOOK_ERROR_SUCCESS) UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook failed: %hs"), *DebugSymbolName, funchook_error_message(funchook));
+	if (arg != FUNCHOOK_ERROR_SUCCESS) UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook failed: %hs"), DebugSymbolName, funchook_error_message(funchook));
 
 static void LogDebugAssemblyAnalyzer(const ANSICHAR* Message) {
 	UE_LOG(LogNativeHookManager, Display, TEXT("AssemblyAnalyzer Debug: %hs"), Message);
 }
 
-static FunctionInfo DiscoverMemberFunction(const FString& DebugSymbolName, FMemberFunctionPointer& MemberFunctionPointer) {
+static FunctionInfo DiscoverMemberFunction(const TCHAR* DebugSymbolName, FMemberFunctionPointer& MemberFunctionPointer) {
 	SetDebugLoggingHook(&LogDebugAssemblyAnalyzer);
 
 #ifndef _WIN64
@@ -68,9 +68,9 @@ static FunctionInfo DiscoverMemberFunction(const FString& DebugSymbolName, FMemb
 	//   * On Windows, all functions (virtual and non-virtual) have a valid address.
 	//   * On Linux, only virtual functions don't and they have already been handled above.
 
-	UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to discover %s at %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to discover %s at %p"), DebugSymbolName, MemberFunctionPointer.FunctionAddress);
 	FunctionInfo FunctionInfo = DiscoverFunction((uint8*)MemberFunctionPointer.FunctionAddress);
-	checkf(FunctionInfo.bIsValid, TEXT("Attempt to hook invalid function %s: Provided code pointer %p is not valid"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+	checkf(FunctionInfo.bIsValid, TEXT("Attempt to hook invalid function %s: Provided code pointer %p is not valid"), DebugSymbolName, MemberFunctionPointer.FunctionAddress);
 
 #ifdef _WIN64
 	// We assign the vtable offset from the FunctionInfo struct whether we found a vtable offset or not. If the
@@ -93,7 +93,7 @@ static void** GetVtableEntry(const FMemberFunctionPointer& MemberFunctionPointer
 
 // Installs a hook a the original function. Returns true if a new hook is installed or false on error or
 // a hook already exists and is reused.
-static bool HookStandardFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, void* HookFunctionPointer, void** OutTrampolineFunction) {
+static bool HookStandardFunction(const TCHAR* DebugSymbolName, void* OriginalFunctionPointer, void* HookFunctionPointer, void** OutTrampolineFunction) {
 	if (const FStandardHook* StandardHook = StandardHookMap.Find(OriginalFunctionPointer)) {
 		//Hook already installed, set trampoline function and return
 		*OutTrampolineFunction = StandardHook->Trampoline;
@@ -103,11 +103,11 @@ static bool HookStandardFunction(const FString& DebugSymbolName, void* OriginalF
 
 	funchook* funchook = funchook_create();
 	if (funchook == nullptr) {
-		UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook_create() returned NULL"), *DebugSymbolName);
+		UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook_create() returned NULL"), DebugSymbolName);
 		return false;
 	}
 
-	UE_LOG(LogNativeHookManager, Display, TEXT("Overriding %s at %p to %p"), *DebugSymbolName, OriginalFunctionPointer, HookFunctionPointer);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Overriding %s at %p to %p"), DebugSymbolName, OriginalFunctionPointer, HookFunctionPointer);
 	*OutTrampolineFunction = OriginalFunctionPointer;
 	CHECK_FUNCHOOK_ERR(funchook_prepare(funchook, OutTrampolineFunction, HookFunctionPointer));
 	CHECK_FUNCHOOK_ERR(funchook_install(funchook, 0));
@@ -116,54 +116,58 @@ static bool HookStandardFunction(const FString& DebugSymbolName, void* OriginalF
 	return true;
 }
 
-// This method is provided for backwards-compatibility
 void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, const void* SampleObjectInstance, int ThisAdjustment, void* HookFunctionPointer, void** OutTrampolineFunction) {
 	// Previous SML versions only supported Windows mods, which have no Vtable adjustment information
 	// in the member function pointer, so we set that value to zero.
 	FMemberFunctionPointer MemberFunctionPointer = {OriginalFunctionPointer, static_cast<uint32>(ThisAdjustment), 0};
-	return FNativeHookManagerInternal::RegisterHookFunction(DebugSymbolName, MemberFunctionPointer, SampleObjectInstance, HookFunctionPointer, OutTrampolineFunction);
+	return RegisterHookFunction(*DebugSymbolName, MemberFunctionPointer, SampleObjectInstance, HookFunctionPointer, OutTrampolineFunction);
 }
 
 void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction) {
+	// Previous SML versions used a dynamically-allocated string for the debug name.
+	return RegisterHookFunction(*DebugSymbolName, MemberFunctionPointer, SampleObjectInstance, HookFunctionPointer, OutTrampolineFunction);
+}
+
+void* FNativeHookManagerInternal::RegisterHookFunction(const TCHAR* DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction) {
 	FunctionInfo FunctionInfo = DiscoverMemberFunction(DebugSymbolName, MemberFunctionPointer);
 
 	if (FunctionInfo.bIsVirtualFunction) {
 		// The patched call is virtual. Calculate the actual address of the function being called.
 		checkf(SampleObjectInstance, TEXT("Attempt to hook virtual function override without providing object instance for implementation resolution"));
-		UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to resolve virtual function %s. This adjustment: 0x%x, virtual function table offset: 0x%x"), *DebugSymbolName, MemberFunctionPointer.ThisAdjustment, MemberFunctionPointer.VtableDisplacement);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to resolve virtual function %s. This adjustment: 0x%x, virtual function table offset: 0x%x"), DebugSymbolName, MemberFunctionPointer.ThisAdjustment, MemberFunctionPointer.VtableDisplacement);
 
 		void* FunctionImplementationPointer = *GetVtableEntry(MemberFunctionPointer, SampleObjectInstance);
 		FunctionInfo = DiscoverFunction((uint8*)FunctionImplementationPointer);
 
 		//Perform basic checking to make sure calculation was correct, or at least seems to be so
-		checkf(FunctionInfo.bIsValid, TEXT("Failed to resolve virtual function for thunk %s at %p, resulting address contains no executable code"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
-		checkf(!FunctionInfo.bIsVirtualFunction, TEXT("Failed to resolve virtual function for thunk %s at %p, resulting function still points to a thunk"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+		checkf(FunctionInfo.bIsValid, TEXT("Failed to resolve virtual function for thunk %s at %p, resulting address contains no executable code"), DebugSymbolName, MemberFunctionPointer.FunctionAddress);
+		checkf(!FunctionInfo.bIsVirtualFunction, TEXT("Failed to resolve virtual function for thunk %s at %p, resulting function still points to a thunk"), DebugSymbolName, MemberFunctionPointer.FunctionAddress);
 
-		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully resolved virtual function thunk %s at %p to function implementation at %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress, FunctionInfo.RealFunctionAddress);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully resolved virtual function thunk %s at %p to function implementation at %p"), DebugSymbolName, MemberFunctionPointer.FunctionAddress, FunctionInfo.RealFunctionAddress);
 	}
 
 	//Log debugging information just in case
 	void* ResolvedHookingFunctionPointer = FunctionInfo.RealFunctionAddress;
-	UE_LOG(LogNativeHookManager, Display, TEXT("Hooking function %s: Provided address: %p, resolved address: %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress, ResolvedHookingFunctionPointer);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Hooking function %s: Provided address: %p, resolved address: %p"), DebugSymbolName, MemberFunctionPointer.FunctionAddress, ResolvedHookingFunctionPointer);
 
 	HookStandardFunction(DebugSymbolName, ResolvedHookingFunctionPointer, HookFunctionPointer, OutTrampolineFunction);
-	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked function %s at %p"), *DebugSymbolName, ResolvedHookingFunctionPointer);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked function %s at %p"), DebugSymbolName, ResolvedHookingFunctionPointer);
 	return ResolvedHookingFunctionPointer;
 }
 
-void FNativeHookManagerInternal::UnregisterHookFunction(const FString& DebugSymbolName, const void* RealFunctionAddress) {
+void FNativeHookManagerInternal::UnregisterHookFunction(const TCHAR* DebugSymbolName, const void* RealFunctionAddress) {
 	FStandardHook StandardHook;
 	if (!StandardHookMap.RemoveAndCopyValue(RealFunctionAddress, StandardHook)) {
-		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister hook for function %s at %p which was not registered"), *DebugSymbolName, RealFunctionAddress);
+		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister hook for function %s at %p which was not registered"), DebugSymbolName, RealFunctionAddress);
 		return;
 	}
 	funchook_t* funchook = StandardHook.FuncHook;
 	CHECK_FUNCHOOK_ERR(funchook_uninstall(funchook, 0));
 	CHECK_FUNCHOOK_ERR(funchook_destroy(funchook));
-	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered hook for function %s at %p"), *DebugSymbolName, RealFunctionAddress);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered hook for function %s at %p"), DebugSymbolName, RealFunctionAddress);
 }
 
-static void SetVtableEntry(const FString& DebugSymbolName, void** VtableEntry, void* NewValue)
+static void SetVtableEntry(const TCHAR* DebugSymbolName, void** VtableEntry, void* NewValue)
 {
 	// FPlatformMemory doesn't seem to have a way to get the old page protections back, but it's a good
 	// bet that it was a read-only page.
@@ -172,18 +176,18 @@ static void SetVtableEntry(const FString& DebugSymbolName, void** VtableEntry, v
 	void* PageStart = AlignDown(VtableEntry, PageSize);
 
 	verifyf(FPlatformMemory::PageProtect(PageStart, PageSize, true, true),
-		TEXT("Failed to un-protect vtable entry for function %s at %p"), *DebugSymbolName, VtableEntry);
+		TEXT("Failed to un-protect vtable entry for function %s at %p"), DebugSymbolName, VtableEntry);
 
 	*VtableEntry = NewValue;
 
 	verifyf(FPlatformMemory::PageProtect(PageStart, PageSize, true, false),
-		TEXT("Failed to re-protect vtable entry for function %s at %p"), *DebugSymbolName, VtableEntry);
+		TEXT("Failed to re-protect vtable entry for function %s at %p"), DebugSymbolName, VtableEntry);
 }
 
-void** FNativeHookManagerInternal::RegisterVtableHook(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutOriginalFunction)
+void** FNativeHookManagerInternal::RegisterVtableHook(const TCHAR* DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutOriginalFunction)
 {
 	const FunctionInfo FunctionInfo = DiscoverMemberFunction(DebugSymbolName, MemberFunctionPointer);
-	checkf(FunctionInfo.bIsVirtualFunction, TEXT("Attempt to hook non-virtual function %s"), *DebugSymbolName);
+	checkf(FunctionInfo.bIsVirtualFunction, TEXT("Attempt to hook non-virtual function %s"), DebugSymbolName);
 	void** VtableEntry = GetVtableEntry(MemberFunctionPointer, SampleObjectInstance);
 	void*& MapOriginalFunction = VtableHookMap.FindOrAdd(VtableEntry);
 
@@ -191,59 +195,54 @@ void** FNativeHookManagerInternal::RegisterVtableHook(const FString& DebugSymbol
 	{
 		MapOriginalFunction = *VtableEntry;
 		SetVtableEntry(DebugSymbolName, VtableEntry, HookFunctionPointer);
-		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked vtable entry for %s at %p"), *DebugSymbolName, VtableEntry);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked vtable entry for %s at %p"), DebugSymbolName, VtableEntry);
 	}
 
 	*OutOriginalFunction = MapOriginalFunction;
 	return VtableEntry;
 }
 
-void FNativeHookManagerInternal::UnregisterVtableHook(const FString& DebugSymbolName, void** VtableEntry)
+void FNativeHookManagerInternal::UnregisterVtableHook(const TCHAR* DebugSymbolName, void** VtableEntry)
 {
 	void* OriginalFunction;
 
 	if (!VtableHookMap.RemoveAndCopyValue(VtableEntry, OriginalFunction))
 	{
-		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister vtable hook for %s at %p which was not registered"), *DebugSymbolName, VtableEntry);
+		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister vtable hook for %s at %p which was not registered"), DebugSymbolName, VtableEntry);
 		return;
 	}
 
 	SetVtableEntry(DebugSymbolName, VtableEntry, OriginalFunction);
-	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered vtable hook for %s at %p"), *DebugSymbolName, VtableEntry);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered vtable hook for %s at %p"), DebugSymbolName, VtableEntry);
 }
 
-UFunction* FNativeHookManagerInternal::RegisterUFunctionHook(UClass* Class, FName FunctionName, FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction)
+UFunction* FNativeHookManagerInternal::RegisterUFunctionHook(const TCHAR* DebugSymbolName, UClass* Class, FName FunctionName, FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction)
 {
-	TStringBuilder<1024> DebugSymbolName;
-	Class->GetFName().AppendString(DebugSymbolName);
-	DebugSymbolName << TEXT("::");
-	FunctionName.AppendString(DebugSymbolName);
-
 	UFunction* Function = Class->FindFunctionByName(FunctionName);
-	checkf(Function, TEXT("Failed to find UFunction %s"), *DebugSymbolName);
+	checkf(Function, TEXT("Failed to find UFunction %s"), DebugSymbolName);
 	FNativeFuncPtr& MapOriginalFunction = UFunctionHookMap.FindOrAdd(Function);
 
 	if (MapOriginalFunction == nullptr)
 	{
 		MapOriginalFunction = Function->GetNativeFunc();
 		Function->SetNativeFunc(HookFunctionPointer);
-		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked UFunction %s (%p)"), *DebugSymbolName, Function);
+		UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked UFunction %s (%p)"), DebugSymbolName, Function);
 	}
 
 	*OutOriginalFunction = MapOriginalFunction;
 	return Function;
 }
 
-void FNativeHookManagerInternal::UnregisterUFunctionHook(const FString& DebugSymbolName, UFunction* Function)
+void FNativeHookManagerInternal::UnregisterUFunctionHook(const TCHAR* DebugSymbolName, UFunction* Function)
 {
 	FNativeFuncPtr OriginalFunction;
 
 	if (!UFunctionHookMap.RemoveAndCopyValue(Function, OriginalFunction))
 	{
-		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister UFunction hook for %s which is not registered"), *DebugSymbolName);
+		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister UFunction hook for %s which is not registered"), DebugSymbolName);
 		return;
 	}
 
 	Function->SetNativeFunc(OriginalFunction);
-	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered UFunction hook %s"), *DebugSymbolName);
+	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered UFunction hook %s"), DebugSymbolName);
 }

--- a/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
+++ b/Mods/SML/Source/SML/Private/Patching/NativeHookManager.cpp
@@ -5,75 +5,80 @@
 
 DEFINE_LOG_CATEGORY(LogNativeHookManager);
 
+namespace
+{
+	struct FStandardHook
+	{
+		void* Trampoline;
+		funchook* FuncHook;
+	};
+}
+
 //since templates are actually compiled for each module separately,
 //we need to have a global handler map which will be shared by all hook invoker templates available in all modules
 //to keep single hook instance for each method
-static TMap<void*, void*> RegisteredListenerMap;
+static TMap<void*, void*> HandlerListMap;
+static TMap<const void* /* RealFunctionAddress */, FStandardHook> StandardHookMap;
 
-//Map of the function implementation pointer to the trampoline function pointer. Used to ensure one hook per function installed
-static TMap<void*, void*> InstalledHookMap;
-
-//Store the funchook instance used to hook each function
-static TMap<void*, funchook_t*> FunchookMap;
-
-void* FNativeHookManagerInternal::GetHandlerListInternal( const void* RealFunctionAddress ) {
-	void** ExistingMapEntry = RegisteredListenerMap.Find(RealFunctionAddress);
+void* FNativeHookManagerInternal::GetHandlerListInternal(const void* Key)
+{
+	void** ExistingMapEntry = HandlerListMap.Find(Key);
 	return ExistingMapEntry ? *ExistingMapEntry : nullptr;
 }
 
-void FNativeHookManagerInternal::SetHandlerListInstanceInternal(void* RealFunctionAddress, void* HandlerList)
+void FNativeHookManagerInternal::SetHandlerListInstanceInternal(void* Key, void* HandlerList)
 {
-	if ( HandlerList == nullptr )
+	if (HandlerList == nullptr)
 	{
-		RegisteredListenerMap.Remove( RealFunctionAddress );
+		HandlerListMap.Remove(Key);
 	}
 	else
 	{
-		RegisteredListenerMap.Add(RealFunctionAddress, HandlerList);
+		HandlerListMap.Add(Key, HandlerList);
 	}
 }
 
 #define CHECK_FUNCHOOK_ERR(arg) \
 	if (arg != FUNCHOOK_ERROR_SUCCESS) UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook failed: %hs"), *DebugSymbolName, funchook_error_message(funchook));
 
-void LogDebugAssemblyAnalyzer(const ANSICHAR* Message) {
+static void LogDebugAssemblyAnalyzer(const ANSICHAR* Message) {
 	UE_LOG(LogNativeHookManager, Display, TEXT("AssemblyAnalyzer Debug: %hs"), Message);
 }
 
 // Installs a hook a the original function. Returns true if a new hook is installed or false on error or
 // a hook already exists and is reused.
-bool HookStandardFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, void* HookFunctionPointer, void** OutTrampolineFunction) {
-	if (InstalledHookMap.Contains(OriginalFunctionPointer)) {
+static bool HookStandardFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, void* HookFunctionPointer, void** OutTrampolineFunction) {
+	if (const FStandardHook* StandardHook = StandardHookMap.Find(OriginalFunctionPointer)) {
 		//Hook already installed, set trampoline function and return
-		*OutTrampolineFunction = InstalledHookMap.FindChecked(OriginalFunctionPointer);
+		*OutTrampolineFunction = StandardHook->Trampoline;
 		UE_LOG(LogNativeHookManager, Display, TEXT("Hook already installed"));
 		return false;
 	}
+
 	funchook* funchook = funchook_create();
 	if (funchook == nullptr) {
 		UE_LOG(LogNativeHookManager, Fatal, TEXT("Hooking function %s failed: funchook_create() returned NULL"), *DebugSymbolName);
 		return false;
 	}
-	*OutTrampolineFunction = OriginalFunctionPointer;
 
 	UE_LOG(LogNativeHookManager, Display, TEXT("Overriding %s at %p to %p"), *DebugSymbolName, OriginalFunctionPointer, HookFunctionPointer);
-
+	*OutTrampolineFunction = OriginalFunctionPointer;
 	CHECK_FUNCHOOK_ERR(funchook_prepare(funchook, OutTrampolineFunction, HookFunctionPointer));
 	CHECK_FUNCHOOK_ERR(funchook_install(funchook, 0));
-	InstalledHookMap.Add(OriginalFunctionPointer, *OutTrampolineFunction);
-	FunchookMap.Add(OriginalFunctionPointer, funchook);
+	StandardHookMap.Add(OriginalFunctionPointer, FStandardHook{*OutTrampolineFunction, funchook});
+
 	return true;
 }
 
 // This method is provided for backwards-compatibility
-SML_API void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, const void* SampleObjectInstance, int ThisAdjustment, void* HookFunctionPointer, void** OutTrampolineFunction) {
+void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, const void* SampleObjectInstance, int ThisAdjustment, void* HookFunctionPointer, void** OutTrampolineFunction) {
 	// Previous SML versions only supported Windows mods, which have no Vtable adjustment information
 	// in the member function pointer, so we set that value to zero.
 	FMemberFunctionPointer MemberFunctionPointer = {OriginalFunctionPointer, static_cast<uint32>(ThisAdjustment), 0};
 	return FNativeHookManagerInternal::RegisterHookFunction(DebugSymbolName, MemberFunctionPointer, SampleObjectInstance, HookFunctionPointer, OutTrampolineFunction);
 }
 
-SML_API void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction) {
+void* FNativeHookManagerInternal::RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction) {
 	SetDebugLoggingHook(&LogDebugAssemblyAnalyzer);
 
 #ifdef _WIN64
@@ -102,7 +107,7 @@ SML_API void* FNativeHookManagerInternal::RegisterHookFunction(const FString& De
 		// The patched call is virtual. Calculate the actual address of the function being called.
 		checkf(SampleObjectInstance, TEXT("Attempt to hook virtual function override without providing object instance for implementation resolution"));
 		UE_LOG(LogNativeHookManager, Display, TEXT("Attempting to resolve virtual function %s. This adjustment: 0x%x, virtual function table offset: 0x%x"), *DebugSymbolName, MemberFunctionPointer.ThisAdjustment, MemberFunctionPointer.VtableDisplacement);
-		
+
 		//Target Function Address = (this + ThisAdjustment)->vftable[VirtualFunctionOffset]
 		void* AdjustedThisPointer = ((uint8*) SampleObjectInstance) + MemberFunctionPointer.ThisAdjustment;
 		uint8** VirtualFunctionTableBase = *((uint8***) AdjustedThisPointer);
@@ -121,22 +126,20 @@ SML_API void* FNativeHookManagerInternal::RegisterHookFunction(const FString& De
 	//Log debugging information just in case
 	void* ResolvedHookingFunctionPointer = FunctionInfo.RealFunctionAddress;
 	UE_LOG(LogNativeHookManager, Display, TEXT("Hooking function %s: Provided address: %p, resolved address: %p"), *DebugSymbolName, MemberFunctionPointer.FunctionAddress, ResolvedHookingFunctionPointer);
-	
+
 	HookStandardFunction(DebugSymbolName, ResolvedHookingFunctionPointer, HookFunctionPointer, OutTrampolineFunction);
 	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully hooked function %s at %p"), *DebugSymbolName, ResolvedHookingFunctionPointer);
 	return ResolvedHookingFunctionPointer;
 }
 
 void FNativeHookManagerInternal::UnregisterHookFunction(const FString& DebugSymbolName, const void* RealFunctionAddress) {
-	funchook_t** funchookPtr = FunchookMap.Find(RealFunctionAddress);
-	if (funchookPtr == nullptr) {
+	FStandardHook StandardHook;
+	if (!StandardHookMap.RemoveAndCopyValue(RealFunctionAddress, StandardHook)) {
 		UE_LOG(LogNativeHookManager, Warning, TEXT("Attempt to unregister hook for function %s at %p which was not registered"), *DebugSymbolName, RealFunctionAddress);
 		return;
 	}
-	funchook_t* funchook = *funchookPtr;
+	funchook_t* funchook = StandardHook.FuncHook;
 	CHECK_FUNCHOOK_ERR(funchook_uninstall(funchook, 0));
 	CHECK_FUNCHOOK_ERR(funchook_destroy(funchook));
-	FunchookMap.Remove(RealFunctionAddress);
-	InstalledHookMap.Remove(RealFunctionAddress);
 	UE_LOG(LogNativeHookManager, Display, TEXT("Successfully unregistered hook for function %s at %p"), *DebugSymbolName, RealFunctionAddress);
 }

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "CoreMinimal.h"
+#include "Reflection/FunctionThunkGenerator.h"
 #include <type_traits>
 
 SML_API DECLARE_LOG_CATEGORY_EXTERN(LogNativeHookManager, Log, Log);
@@ -63,7 +64,7 @@ FORCEINLINE FMemberFunctionPointer ConvertFunctionPointer(const T& SourcePointer
 	if (FunctionPointerSize >= 16) {
 		ResultPointer.ThisAdjustment = RawFunctionPointer->ThisAdjustment;
 		// The vtable displacement here is only valid if the method is NOT virtual. If the method IS virtual,
-		// the vtable offset will be found in the thunk. See FNativeHookManagerInternal::RegisterHookFunction()
+		// the vtable offset will be found in the thunk. See DiscoverMemberFunction().
 		ResultPointer.VtableDisplacement = RawFunctionPointer->VtableDisplacement;
 	} else {
 		// The function pointer contains no information about a `this` adjustment or the vtable displacement.
@@ -82,7 +83,7 @@ FORCEINLINE FMemberFunctionPointer ConvertFunctionPointer(const T& SourcePointer
 		//UE_LOG(LogNativeHookManager, Display, TEXT("Member pointer looks like a Vtable offset: 0x%08x."), RawFunctionPointer->IntPtr);
 
 		// We mark this method as virtual by leaving the original function pointer null. This works in concert with
-		// RegisterHookFunction().
+		// DiscoverMemberFunction().
 		ResultPointer.VtableDisplacement = RawFunctionPointer->VtableDisplacementPlusOne - 1;
 	} else if ((RawFunctionPointer->IntPtr & 0x7) == 0) {
 		//UE_LOG(LogNativeHookManager, Display, TEXT("Member pointer looks like a function pointer: 0x%08x"), RawFunctionPointer->IntPtr);
@@ -106,6 +107,11 @@ public:
 	static void* RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
 	                                  void* HookFunctionPointer, void** OutTrampolineFunction);
 	static void UnregisterHookFunction(const FString& DebugSymbolName, const void* RealFunctionAddress);
+	static void** RegisterVtableHook(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
+	                                 void* HookFunctionPointer, void** OutOriginalFunction);
+	static void UnregisterVtableHook(const FString& DebugSymbolName, void** VtableEntry);
+	static UFunction* RegisterUFunctionHook(UClass* Class, FName FunctionName, FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction);
+	static void UnregisterUFunctionHook(const FString& DebugSymbolName, UFunction* Function);
 
 	// A call to this function signature is inlined in mods
 	// Keep it for backwards compatibility
@@ -278,6 +284,66 @@ struct TStandardHookBackend
 	}
 };
 
+template<typename TCallable, TCallable OriginalFunction>
+struct TVtableHookBackend
+{
+	// Key = VtableEntry
+
+	template<auto HookFunction>
+	static FNativeHookResult RegisterHook(const FString& DebugSymbolName, const void* SampleObjectInstance)
+	{
+		FNativeHookResult Result;
+
+		Result.Key = FNativeHookManagerInternal::RegisterVtableHook(
+			DebugSymbolName,
+			ConvertFunctionPointer(OriginalFunction),
+			SampleObjectInstance,
+			(void*)HookFunction,
+			&Result.OriginalFunctionCode);
+
+		return Result;
+	}
+
+	static void UnregisterHook(const FString& DebugSymbolName, void* Key)
+	{
+		auto VtableEntry = static_cast<void**>(Key);
+		FNativeHookManagerInternal::UnregisterVtableHook(DebugSymbolName, VtableEntry);
+	}
+};
+
+template<typename ClassType, auto ImplFunction>
+struct TUFunctionHookBackend
+{
+	// Key = UFunction
+
+	template<auto HookFunction>
+	static consteval FNativeFuncPtr WrapHookFunction()
+	{
+		// Wrap the hook in a UFunction thunk.
+		return &TFunctionThunkGenerator<decltype(ImplFunction)>::template Thunk<HookFunction>;
+	}
+
+	template<FNativeFuncPtr HookFunction>
+	static FNativeHookResult RegisterHook(FName FunctionName)
+	{
+		FNativeHookResult Result;
+
+		Result.Key = FNativeHookManagerInternal::RegisterUFunctionHook(
+			ClassType::StaticClass(),
+			FunctionName,
+			HookFunction,
+			(FNativeFuncPtr*)&Result.OriginalFunctionCode);
+
+		return Result;
+	}
+
+	static void UnregisterHook(const FString& DebugSymbolName, void* Key)
+	{
+		auto Function = static_cast<UFunction*>(Key);
+		FNativeHookManagerInternal::UnregisterUFunctionHook(DebugSymbolName, Function);
+	}
+};
+
 template<typename Backend, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
 class THookInvokerBase
 {
@@ -335,7 +401,7 @@ private:
 		if (OriginalFunctionCode != nullptr)
 			return;	// Already installed.
 
-		constexpr auto HookFunction = &GenerateHookFunction<ArgTypes...>::ApplyCall;
+		constexpr auto HookFunction = GetHookFunction();
 		const FNativeHookResult Result = Backend::template RegisterHook<HookFunction>(Forward<BackendArgTypes>(BackendArgs)...);
 		auto* HandlerLists = CreateHandlerLists<HandlerBefore, HandlerAfter>(Result.Key);
 
@@ -385,6 +451,27 @@ private:
 		}
 	}
 
+	// If the actual function signature is different from what's presented to the user, e.g. if there's
+	// a custom thunk that forwards to the user-facing function, then the backend can provide its own
+	// hook function with the expectation that it'll forward the call on to our hook function.
+	static constexpr bool bBackendWrapsHookFunction = requires
+	{
+		Backend::template WrapHookFunction<static_cast<CallableType*>(nullptr)>();
+	};
+
+	static consteval auto GetHookFunction()
+	{
+		constexpr auto DefaultHookFunction = &GenerateHookFunction<ArgTypes...>::ApplyCall;
+		if constexpr (bBackendWrapsHookFunction)
+		{
+			return Backend::template WrapHookFunction<DefaultHookFunction>();
+		}
+		else
+		{
+			return DefaultHookFunction;
+		}
+	}
+
 	template<typename... /* ArgTypes */>
 	struct GenerateHookFunction
 	{
@@ -427,7 +514,8 @@ private:
 	// This isn't a problem on Linux because System V doesn't treat non-static member functions any
 	// differently, so emulating one with an explicit "this" parameter doesn't cause any issues.
 	template<typename ThisPointer, typename... OtherArgTypes>
-		requires (bIsMemberFunction && (std::is_class_v<ReturnType> || std::is_union_v<ReturnType>))
+		requires (bIsMemberFunction && !bBackendWrapsHookFunction
+		          && (std::is_class_v<ReturnType> || std::is_union_v<ReturnType>))
 	struct GenerateHookFunction<ThisPointer, OtherArgTypes...>
 	{
 		static ReturnType* ApplyCall(ThisPointer Self, ReturnType* OutReturnValue, OtherArgTypes... Args)
@@ -550,3 +638,58 @@ using CallScope = TCallScope<T>;
 
 #define UNSUBSCRIBE_UOBJECT_METHOD_EXPLICIT(MethodSignature, ObjectClass, MethodName, HandlerHandle) \
 	UNSUBSCRIBE_METHOD_EXPLICIT(MethodSignature, ObjectClass::MethodName, HandlerHandle)
+
+//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// WARNING
+// The hook types defined below are for very specific advanced use cases. In most cases, the
+// functionality provided above should suffice.
+//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+/*
+ * SUBSCRIBE_VTABLE_ENTRY
+ * The hook will only be called if the function is called virtually!
+ */
+
+#define SUBSCRIBE_VTABLE_ENTRY(MethodReference, SampleObjectInstance, Handler) \
+	SUBSCRIBE_VTABLE_ENTRY_EXPLICIT(decltype(&MethodReference), MethodReference, SampleObjectInstance, Handler)
+
+#define SUBSCRIBE_VTABLE_ENTRY_AFTER(MethodReference, SampleObjectInstance, Handler) \
+	SUBSCRIBE_VTABLE_ENTRY_EXPLICIT_AFTER(decltype(&MethodReference), MethodReference, SampleObjectInstance, Handler)
+
+#define SUBSCRIBE_VTABLE_ENTRY_EXPLICIT(MethodSignature, MethodReference, SampleObjectInstance, Handler) \
+	INTERNAL_SUBSCRIBE_VTABLE_ENTRY(Before, MethodSignature, MethodReference, SampleObjectInstance, Handler)
+
+#define SUBSCRIBE_VTABLE_ENTRY_EXPLICIT_AFTER(MethodSignature, MethodReference, SampleObjectInstance, Handler) \
+	INTERNAL_SUBSCRIBE_VTABLE_ENTRY(After, MethodSignature, MethodReference, SampleObjectInstance, Handler)
+
+#define INTERNAL_SUBSCRIBE_VTABLE_ENTRY(HandlerKind, MethodSignature, MethodReference, SampleObjectInstance, Handler) \
+	THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
+		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance)
+
+#define UNSUBSCRIBE_VTABLE_ENTRY(MethodReference, HandlerHandle) \
+	UNSUBSCRIBE_VTABLE_ENTRY_EXPLICIT(decltype(&MethodReference), MethodReference, HandlerHandle)
+
+#define UNSUBSCRIBE_VTABLE_ENTRY_EXPLICIT(MethodSignature, MethodReference, HandlerHandle) \
+	THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
+		::RemoveHandler(HandlerHandle, TEXT(#MethodReference))
+
+/*
+ * SUBSCRIBE_UFUNCTION_VM
+ * The hook will only be called if the function is called via the reflection system!
+ */
+
+// There're no "explicit" variants of these macros because UFunctions can't be overloaded.
+
+#define SUBSCRIBE_UFUNCTION_VM(ObjectClass, MethodName, Handler) \
+	INTERNAL_SUBSCRIBE_UFUNCTION_VM(Before, ObjectClass, MethodName, Handler)
+
+#define SUBSCRIBE_UFUNCTION_VM_AFTER(ObjectClass, MethodName, Handler) \
+	INTERNAL_SUBSCRIBE_UFUNCTION_VM(After, ObjectClass, MethodName, Handler)
+
+#define INTERNAL_SUBSCRIBE_UFUNCTION_VM(HandlerKind, ObjectClass, MethodName, Handler) \
+	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \
+		::AddHandler##HandlerKind(Handler, TEXT(#MethodName))
+
+#define UNSUBSCRIBE_UFUNCTION_VM(ObjectClass, MethodName, HandlerHandle) \
+	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \
+		::RemoveHandler(HandlerHandle, TEXT(#ObjectClass "::" #MethodName))

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -246,6 +246,79 @@ public:
 	}
 };
 
+/// Handle returned from hooking functions.
+/// If you want to be able to unhook, you should store the handle and call Unsubscribe() when ready.
+/// Otherwise you can safely ignore it.
+class FNativeHookHandle
+{
+	template<typename Backend, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
+	friend class THookInvokerBase;
+
+private:
+	// Most people will ignore the return value from hooking functions, as they tend not to care about
+	// unsubscribing. If we were to return a real handle then we'd be instantiating the unsubscribing
+	// code for everyone, which would cause unecessary code bloat. Instead we return this intermediate
+	// type that doesn't actually reference the unsubscribing functions unless a real handle is
+	// constructed from it, which means that no one will pay that cost unless they want it. This should
+	// be invisible to the user, they should either construct a handle or ignore the result; the
+	// existence of this intermediate type is an implementation detail.
+	template<typename HookInvoker>
+	struct TDelayedInit
+	{
+		friend FNativeHookHandle;
+		friend HookInvoker;
+
+	private:
+		TDelayedInit() = default;
+
+		TDelayedInit(FDelegateHandle DelegateHandle, const TCHAR* DebugSymbolName)
+			: DelegateHandle(DelegateHandle)
+			, DebugSymbolName(DebugSymbolName)
+		{
+		}
+
+		FDelegateHandle DelegateHandle = {};
+		const TCHAR* DebugSymbolName = nullptr;
+
+	public:
+		// This function is provided in case someone stores this object directly with `auto` instead of
+		// making a real FNativeHookHandle out of it.
+		void Unsubscribe()
+		{
+			if (DelegateHandle.IsValid())
+			{
+				HookInvoker::RemoveHandler(DelegateHandle, DebugSymbolName);
+				*this = {};
+			}
+		}
+	};
+
+public:
+	FNativeHookHandle() = default;
+
+	template<typename HookInvoker>
+	FNativeHookHandle(TDelayedInit<HookInvoker> Params)
+		: RemoveHandler(&HookInvoker::RemoveHandler)
+		, DelegateHandle(Params.DelegateHandle)
+		, DebugSymbolName(Params.DebugSymbolName)
+	{
+	}
+
+	void Unsubscribe()
+	{
+		if (RemoveHandler != nullptr)
+		{
+			RemoveHandler(DelegateHandle, DebugSymbolName);
+			*this = {};
+		}
+	}
+
+private:
+	void(*RemoveHandler)(FDelegateHandle, const TCHAR* DebugSymbolName) = nullptr;
+	FDelegateHandle DelegateHandle = {};
+	const TCHAR* DebugSymbolName = nullptr;
+};
+
 struct FNativeHookResult
 {
 	/// Value that uniquely identifies this hook, must be the same across all modules. The actual
@@ -365,21 +438,22 @@ public:
 	using HandlerAfter = TFunction<HandlerAfterSignature>;
 
 	template<typename... BackendArgTypes>
-	static FDelegateHandle AddHandlerBefore(HandlerBefore&& InHandler, BackendArgTypes&&... BackendArgs)
+	static auto AddHandlerBefore(HandlerBefore&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
 	{
-		InstallHook(Forward<BackendArgTypes>(BackendArgs)...);
-		return InternalAddHandler(MoveTemp(InHandler), *HandlersBefore, *HandlerBeforeReferences);
+		InstallHook(DebugSymbolName, Forward<BackendArgTypes>(BackendArgs)...);
+		const FDelegateHandle DelegateHandle = InternalAddHandler(MoveTemp(InHandler), *HandlersBefore, *HandlerBeforeReferences);
+		return FNativeHookHandle::TDelayedInit<THookInvokerBase>(DelegateHandle, DebugSymbolName);
 	}
 
 	template<typename... BackendArgTypes>
-	static FDelegateHandle AddHandlerAfter(HandlerAfter&& InHandler, BackendArgTypes&&... BackendArgs)
+	static auto AddHandlerAfter(HandlerAfter&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
 	{
-		InstallHook(Forward<BackendArgTypes>(BackendArgs)...);
-		return InternalAddHandler(MoveTemp(InHandler), *HandlersAfter, *HandlerAfterReferences);
+		InstallHook(DebugSymbolName, Forward<BackendArgTypes>(BackendArgs)...);
+		const FDelegateHandle DelegateHandle = InternalAddHandler(MoveTemp(InHandler), *HandlersAfter, *HandlerAfterReferences);
+		return FNativeHookHandle::TDelayedInit<THookInvokerBase>(DelegateHandle, DebugSymbolName);
 	}
 
-	template<typename... BackendArgTypes>
-	static void RemoveHandler(FDelegateHandle InHandlerHandle, BackendArgTypes&&... BackendArgs)
+	static void RemoveHandler(FDelegateHandle InHandlerHandle, const TCHAR* DebugSymbolName)
 	{
 		InternalRemoveHandler(InHandlerHandle, *HandlersBefore, *HandlerBeforeReferences);
 		InternalRemoveHandler(InHandlerHandle, *HandlersAfter, *HandlerAfterReferences);
@@ -387,7 +461,7 @@ public:
 		if (HandlersBefore->IsEmpty() && HandlersAfter->IsEmpty())
 		{
 			// No handlers left, uninstall the hook.
-			UninstallHook(Forward<BackendArgTypes>(BackendArgs)...);
+			UninstallHook(DebugSymbolName);
 		}
 	}
 
@@ -398,13 +472,13 @@ private:
 	using HandlersMap = TMap<FDelegateHandle, TSharedPtr<HandlerType>>;
 
 	template<typename... BackendArgTypes>
-	static void InstallHook(BackendArgTypes&&... BackendArgs)
+	static void InstallHook(const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
 	{
 		if (OriginalFunctionCode != nullptr)
 			return;	// Already installed.
 
 		constexpr auto HookFunction = GetHookFunction();
-		const FNativeHookResult Result = Backend::template RegisterHook<HookFunction>(Forward<BackendArgTypes>(BackendArgs)...);
+		const FNativeHookResult Result = Backend::template RegisterHook<HookFunction>(DebugSymbolName, Forward<BackendArgTypes>(BackendArgs)...);
 		auto* HandlerLists = CreateHandlerLists<HandlerBefore, HandlerAfter>(Result.Key);
 
 		HandlersBefore = &HandlerLists->HandlersBefore;
@@ -415,13 +489,12 @@ private:
 		Key = Result.Key;
 	}
 
-	template<typename... BackendArgTypes>
-	static void UninstallHook(BackendArgTypes&&... BackendArgs)
+	static void UninstallHook(const TCHAR* DebugSymbolName)
 	{
 		if (OriginalFunctionCode == nullptr)
 			return;	// Not installed.
 
-		Backend::UnregisterHook(Forward<BackendArgTypes>(BackendArgs)..., Key);
+		Backend::UnregisterHook(DebugSymbolName, Key);
 		DestroyHandlerLists<HandlerBefore, HandlerAfter>(Key);
 
 		HandlersBefore = nullptr;
@@ -624,23 +697,6 @@ using CallScope = TCallScope<T>;
 #define SUBSCRIBE_UOBJECT_METHOD_EXPLICIT_AFTER(MethodSignature, ObjectClass, MethodName, Handler) \
 	SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL_AFTER(MethodSignature, ObjectClass::MethodName, GetDefault<ObjectClass>(), Handler)
 
-/*
- * UNSUBSCRIBE_METHOD
- */
-
-#define UNSUBSCRIBE_METHOD(MethodReference, HandlerHandle) \
-	UNSUBSCRIBE_METHOD_EXPLICIT(decltype(&MethodReference), MethodReference, HandlerHandle)
-
-#define UNSUBSCRIBE_METHOD_EXPLICIT(MethodSignature, MethodReference, HandlerHandle) \
-	THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
-		::RemoveHandler(HandlerHandle, TEXT(#MethodReference))
-
-#define UNSUBSCRIBE_UOBJECT_METHOD(ObjectClass, MethodName, HandlerHandle) \
-	UNSUBSCRIBE_METHOD(ObjectClass::MethodName, HandlerHandle)
-
-#define UNSUBSCRIBE_UOBJECT_METHOD_EXPLICIT(MethodSignature, ObjectClass, MethodName, HandlerHandle) \
-	UNSUBSCRIBE_METHOD_EXPLICIT(MethodSignature, ObjectClass::MethodName, HandlerHandle)
-
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // WARNING
 // The hook types defined below are for very specific advanced use cases. In most cases, the
@@ -668,13 +724,6 @@ using CallScope = TCallScope<T>;
 	THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
 		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance)
 
-#define UNSUBSCRIBE_VTABLE_ENTRY(MethodReference, HandlerHandle) \
-	UNSUBSCRIBE_VTABLE_ENTRY_EXPLICIT(decltype(&MethodReference), MethodReference, HandlerHandle)
-
-#define UNSUBSCRIBE_VTABLE_ENTRY_EXPLICIT(MethodSignature, MethodReference, HandlerHandle) \
-	THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
-		::RemoveHandler(HandlerHandle, TEXT(#MethodReference))
-
 /*
  * SUBSCRIBE_UFUNCTION_VM
  * The hook will only be called if the function is called via the reflection system!
@@ -691,7 +740,3 @@ using CallScope = TCallScope<T>;
 #define INTERNAL_SUBSCRIBE_UFUNCTION_VM(HandlerKind, ObjectClass, MethodName, Handler) \
 	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \
 		::AddHandler##HandlerKind(Handler, TEXT(#ObjectClass "::" #MethodName), TEXT(#MethodName))
-
-#define UNSUBSCRIBE_UFUNCTION_VM(ObjectClass, MethodName, HandlerHandle) \
-	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \
-		::RemoveHandler(HandlerHandle, TEXT(#ObjectClass "::" #MethodName))

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -25,10 +25,20 @@ struct FLinuxMemberFunctionPointer {
 	ptrdiff_t ThisAdjustment;
 };
 
+template<typename Ret, typename... Args>
+FORCEINLINE FMemberFunctionPointer ConvertFunctionPointer(Ret(*SourcePointer)(Args...)) {
+	// Non-member function pointer is just an address.
+	return FMemberFunctionPointer
+	{
+		.FunctionAddress = (void*)SourcePointer,
+	};
+}
+
 template<typename T>
 FORCEINLINE FMemberFunctionPointer ConvertFunctionPointer(const T& SourcePointer) {
+	static_assert(std::is_member_function_pointer_v<T>);
 	const SIZE_T FunctionPointerSize = sizeof(SourcePointer);
-	
+
 #ifdef _WIN64
 	//We only support non-virtual inheritance, so assert on virtual inheritance and unknown inheritance cases
 	//Note that it might also mean that we are dealing with "proper" compiler with static function pointer size
@@ -91,11 +101,11 @@ FORCEINLINE FMemberFunctionPointer ConvertFunctionPointer(const T& SourcePointer
 
 class SML_API FNativeHookManagerInternal {
 public:
-	static void* GetHandlerListInternal( const void* RealFunctionAddress);
-	static void SetHandlerListInstanceInternal(void* RealFunctionAddress, void* HandlerList);
-	static void* RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void*
-	                                  HookFunctionPointer, void** OutTrampolineFunction);
-	static void UnregisterHookFunction( const FString& DebugSymbolName, const void* RealFunctionAddress );
+	static void* GetHandlerListInternal(const void* Key);
+	static void SetHandlerListInstanceInternal(void* Key, void* HandlerList);
+	static void* RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
+	                                  void* HookFunctionPointer, void** OutTrampolineFunction);
+	static void UnregisterHookFunction(const FString& DebugSymbolName, const void* RealFunctionAddress);
 
 	// A call to this function signature is inlined in mods
 	// Keep it for backwards compatibility
@@ -111,31 +121,31 @@ struct THandlerLists {
 };
 
 template <typename T, typename E>
-static THandlerLists<T, E>* CreateHandlerLists( void* RealFunctionAddress )
+static THandlerLists<T, E>* CreateHandlerLists(void* Key)
 {
-	void* HandlerListRaw = FNativeHookManagerInternal::GetHandlerListInternal( RealFunctionAddress );
+	void* HandlerListRaw = FNativeHookManagerInternal::GetHandlerListInternal(Key);
 	if (HandlerListRaw == nullptr) {
 		HandlerListRaw = new THandlerLists<T, E>();
-		FNativeHookManagerInternal::SetHandlerListInstanceInternal( RealFunctionAddress, HandlerListRaw );
+		FNativeHookManagerInternal::SetHandlerListInstanceInternal(Key, HandlerListRaw);
 	}
-	return static_cast<THandlerLists<T, E>*>( HandlerListRaw );
+	return static_cast<THandlerLists<T, E>*>(HandlerListRaw);
 }
 
 template <typename T, typename E>
-static void DestroyHandlerLists( void* RealFunctionAddress )
+static void DestroyHandlerLists(void* Key)
 {
-	void* HandlerListRaw = FNativeHookManagerInternal::GetHandlerListInternal(RealFunctionAddress);
-
+	void* HandlerListRaw = FNativeHookManagerInternal::GetHandlerListInternal(Key);
 	if (HandlerListRaw != nullptr) {
 		const THandlerLists<T, E>* CastedHandlerList = static_cast<THandlerLists<T, E>*>(HandlerListRaw);
 		delete CastedHandlerList;
-		
-		FNativeHookManagerInternal::SetHandlerListInstanceInternal( RealFunctionAddress, nullptr );
+		FNativeHookManagerInternal::SetHandlerListInstanceInternal(Key, nullptr);
 	}
 }
 
-template <typename TCallable, TCallable Callable>
-struct HookInvoker;
+/// Manages handlers and invokes them when the hooked function is called.
+/// The actual hooking is delegated to the backend, which can decide how it wants to hook.
+template<typename Backend, typename TCallable>
+struct THookInvoker;
 
 template<typename TCallable>
 struct TCallScope;
@@ -189,12 +199,12 @@ public:
 	typedef void HookFuncSig(TCallScope<Result(*)(Args...)>&, Args...);
 	typedef TFunction<HookFuncSig> HookFunc;
 
-    typedef TFunction<Result(Args...)> HookType;
+	typedef TFunction<Result(Args...)> HookType;
 private:
 	TArray<TSharedPtr<HookFunc>>* FunctionList;
 	size_t HandlerPtr = 0;
 	HookType Function;
-	
+
 	bool bForwardCall = true;
 	Result ResultData{};
 public:
@@ -203,7 +213,7 @@ public:
 	FORCEINLINE	bool ShouldForwardCall() const {
 		return bForwardCall;
 	}
-	
+
 	FORCEINLINE Result GetResult() {
 		return ResultData;
 	}
@@ -229,431 +239,314 @@ public:
 	}
 };
 
-template<typename Ret, typename... A>
-class HandlerAfterFunc {
-public:
-	typedef void Value(const Ret&, A...);
-};
-template<typename... A>
-class HandlerAfterFunc<void, A...> {
-public:
-	typedef void Value(A...);
+struct FNativeHookResult
+{
+	/// Value that uniquely identifies this hook, must be the same across all modules. The actual
+	/// meaning of the value is up to the backend, it's never interpreted directly and is only used for
+	/// comparisons.
+	void* Key;
+
+	/// Address of the code that will call the original implementation of the function. This must be an
+	/// actual address and not some sort of (member/virtual) function pointer as it will be directly
+	/// jumped to.
+	void* OriginalFunctionCode;
 };
 
-template<typename T>
-struct FMemberFunctionStruct {
-	T MemberFunctionPtr;
+template<typename TCallable, TCallable OriginalFunction>
+struct TStandardHookBackend
+{
+	// Key = RealFunctionAddress
+
+	template<auto HookFunction>
+	static FNativeHookResult RegisterHook(const FString& DebugSymbolName, const void* SampleObjectInstance = NULL)
+	{
+		FNativeHookResult Result;
+
+		Result.Key = FNativeHookManagerInternal::RegisterHookFunction(
+			DebugSymbolName,
+			ConvertFunctionPointer(OriginalFunction),
+			SampleObjectInstance,
+			(void*)HookFunction,
+			&Result.OriginalFunctionCode);
+
+		return Result;
+	}
+
+	static void UnregisterHook(const FString& DebugSymbolName, void* RealFunctionAddress)
+	{
+		FNativeHookManagerInternal::UnregisterHookFunction(DebugSymbolName, RealFunctionAddress);
+	}
 };
 
-//Hook invoker for global functions
-template <typename TCallable, TCallable Callable, typename ReturnType, typename... ArgumentTypes>
-struct HookInvokerExecutorGlobalFunction {
+template<typename Backend, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
+class THookInvokerBase
+{
+	static_assert(!bIsMemberFunction || sizeof...(ArgTypes) >= 1,
+		"Member functions must at least have a 'this' pointer!");
+
+	// For non-void return types, the first parameter is the return value.
+	template<typename R = ReturnType> struct GetHandlerAfterSignature { using type = void(const R&, ArgTypes...); };
+	template<typename R> requires std::is_void_v<R> struct GetHandlerAfterSignature<R> { using type = void(ArgTypes...); };
+
 public:
-	using HookType = TCallable;
-	using ScopeType = TCallScope<TCallable>;
-	using HandlerSignature = void(ScopeType&, ArgumentTypes...);
-	using HandlerSignatureAfter = typename HandlerAfterFunc<ReturnType, ArgumentTypes...>::Value;
-	using Handler = TFunction<HandlerSignature>;
-	using HandlerAfter = TFunction<HandlerSignatureAfter>;
+	using CallableType = ReturnType(ArgTypes...);
+	using ScopeType = TCallScope<CallableType*>;
+	using HandlerBeforeSignature = void(ScopeType&, ArgTypes...);
+	using HandlerAfterSignature = GetHandlerAfterSignature<>::type;
+	using HandlerBefore = TFunction<HandlerBeforeSignature>;
+	using HandlerAfter = TFunction<HandlerAfterSignature>;
+
+	template<typename... BackendArgTypes>
+	static FDelegateHandle AddHandlerBefore(HandlerBefore&& InHandler, BackendArgTypes&&... BackendArgs)
+	{
+		InstallHook(Forward<BackendArgTypes>(BackendArgs)...);
+		return InternalAddHandler(MoveTemp(InHandler), *HandlersBefore, *HandlerBeforeReferences);
+	}
+
+	template<typename... BackendArgTypes>
+	static FDelegateHandle AddHandlerAfter(HandlerAfter&& InHandler, BackendArgTypes&&... BackendArgs)
+	{
+		InstallHook(Forward<BackendArgTypes>(BackendArgs)...);
+		return InternalAddHandler(MoveTemp(InHandler), *HandlersAfter, *HandlerAfterReferences);
+	}
+
+	template<typename... BackendArgTypes>
+	static void RemoveHandler(FDelegateHandle InHandlerHandle, BackendArgTypes&&... BackendArgs)
+	{
+		InternalRemoveHandler(InHandlerHandle, *HandlersBefore, *HandlerBeforeReferences);
+		InternalRemoveHandler(InHandlerHandle, *HandlersAfter, *HandlerAfterReferences);
+
+		if (HandlersBefore->IsEmpty() && HandlersAfter->IsEmpty())
+		{
+			// No handlers left, uninstall the hook.
+			UninstallHook(Forward<BackendArgTypes>(BackendArgs)...);
+		}
+	}
+
 private:
-	static inline TArray<TSharedPtr<Handler>>* HandlersBefore{nullptr};
-	static inline TArray<TSharedPtr<HandlerAfter>>* HandlersAfter{nullptr};
-	static inline TMap<FDelegateHandle, TSharedPtr<Handler>>* HandlerBeforeReferences{nullptr};
-	static inline TMap<FDelegateHandle, TSharedPtr<HandlerAfter>>* HandlerAfterReferences{nullptr};
-	static inline TCallable FunctionPtr{nullptr};
-	static inline void* RealFunctionAddress{nullptr};
-	static inline bool bHookInitialized{false};
-public:
-	static ReturnType ApplyCall(ArgumentTypes... Args)
+	template<typename HandlerType>
+	using HandlersArray = TArray<TSharedPtr<HandlerType>>;
+	template<typename HandlerType>
+	using HandlersMap = TMap<FDelegateHandle, TSharedPtr<HandlerType>>;
+
+	template<typename... BackendArgTypes>
+	static void InstallHook(BackendArgTypes&&... BackendArgs)
 	{
-		ScopeType Scope(HandlersBefore, FunctionPtr);
-		Scope(Args...);
-		for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
-		{
-			(*Handler)(Scope.GetResult(), Args...);
-		}
-		return Scope.GetResult();
+		if (OriginalFunctionCode != nullptr)
+			return;	// Already installed.
+
+		constexpr auto HookFunction = &GenerateHookFunction<ArgTypes...>::ApplyCall;
+		const FNativeHookResult Result = Backend::template RegisterHook<HookFunction>(Forward<BackendArgTypes>(BackendArgs)...);
+		auto* HandlerLists = CreateHandlerLists<HandlerBefore, HandlerAfter>(Result.Key);
+
+		HandlersBefore = &HandlerLists->HandlersBefore;
+		HandlersAfter = &HandlerLists->HandlersAfter;
+		HandlerBeforeReferences = &HandlerLists->HandlerBeforeReferences;
+		HandlerAfterReferences = &HandlerLists->HandlerAfterReferences;
+		OriginalFunctionCode = Result.OriginalFunctionCode;
+		Key = Result.Key;
 	}
 
-	static void ApplyCallVoid(ArgumentTypes... Args)
+	template<typename... BackendArgTypes>
+	static void UninstallHook(BackendArgTypes&&... BackendArgs)
 	{
-		ScopeType Scope(HandlersBefore, FunctionPtr);
-		Scope(Args...);
-		for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
-		{
-			(*Handler)(Args...);
-		}
+		if (OriginalFunctionCode == nullptr)
+			return;	// Not installed.
+
+		Backend::UnregisterHook(Forward<BackendArgTypes>(BackendArgs)..., Key);
+		DestroyHandlerLists<HandlerBefore, HandlerAfter>(Key);
+
+		HandlersBefore = nullptr;
+		HandlersAfter = nullptr;
+		HandlerBeforeReferences = nullptr;
+		HandlerAfterReferences = nullptr;
+		OriginalFunctionCode = nullptr;
+		Key = nullptr;
 	}
 
-private:
-	static TCallable GetApplyRef(std::true_type)
+	template<typename HandlerType>
+	static FDelegateHandle InternalAddHandler(HandlerType&& Handler, HandlersArray<HandlerType>& Array, HandlersMap<HandlerType>& Map)
 	{
-		return &ApplyCallVoid;
-	}
+		const TSharedPtr<HandlerType> NewHandlerPtr = MakeShared<HandlerType>(MoveTemp(Handler));
+		const FDelegateHandle NewDelegateHandle(FDelegateHandle::GenerateNewHandle);
 
-	static TCallable GetApplyRef(std::false_type)
-	{
-		return &ApplyCall;
-	}
+		Array.Add(NewHandlerPtr);
+		Map.Add(NewDelegateHandle, NewHandlerPtr);
 
-	static TCallable GetApplyCall()
-	{
-		return GetApplyRef(std::is_same<ReturnType, void>{});
-	}
-public:
-	//This hook invoker is for global non-member static functions, so we don't have to deal with
-	//member function pointers and virtual functions here
-	static void InstallHook(const FString& DebugSymbolName)
-	{
-		if (!bHookInitialized)
-		{
-			bHookInitialized = true;
-			void* HookFunctionPointer = reinterpret_cast<void*>( GetApplyCall() );
-			RealFunctionAddress = FNativeHookManagerInternal::RegisterHookFunction( DebugSymbolName, { reinterpret_cast<void*>(Callable), 0, 0}, NULL, HookFunctionPointer, (void**) &FunctionPtr );
-			THandlerLists<Handler, HandlerAfter>* HandlerLists = CreateHandlerLists<Handler, HandlerAfter>( RealFunctionAddress );
-
-			HandlersBefore = &HandlerLists->HandlersBefore;
-			HandlersAfter = &HandlerLists->HandlersAfter;
-			HandlerBeforeReferences = &HandlerLists->HandlerBeforeReferences;
-			HandlerAfterReferences = &HandlerLists->HandlerAfterReferences;
-		}
-	}
-
-	// Uninstalls the hook. Also frees the handler lists object.
-	static void UninstallHook(const FString& DebugSymbolName)
-	{
-		if (bHookInitialized)
-		{
-			FNativeHookManagerInternal::UnregisterHookFunction( DebugSymbolName, RealFunctionAddress );
-			DestroyHandlerLists<Handler, HandlerAfter>( RealFunctionAddress );
-			bHookInitialized = false;
-			RealFunctionAddress = nullptr;
-			
-			HandlersBefore = nullptr;
-			HandlersAfter = nullptr;
-			HandlerBeforeReferences = nullptr;
-			HandlerAfterReferences = nullptr;
-		}
-	}
-
-	static FDelegateHandle AddHandlerBefore( Handler&& InHandler )
-	{
-		const TSharedPtr<Handler> NewHandlerPtr = MakeShared<Handler>( MoveTemp( InHandler ) );
-		HandlersBefore->Add( NewHandlerPtr );
-
-		FDelegateHandle NewDelegateHandle( FDelegateHandle::GenerateNewHandle );
-		HandlerBeforeReferences->Add( NewDelegateHandle, NewHandlerPtr );
 		return NewDelegateHandle;
 	}
 
-	static FDelegateHandle AddHandlerAfter( HandlerAfter&& InHandler ) {
-
-		const TSharedPtr<HandlerAfter> NewHandlerPtr = MakeShared<HandlerAfter>( MoveTemp( InHandler ) );
-		HandlersAfter->Add( NewHandlerPtr );
-
-		FDelegateHandle NewDelegateHandle( FDelegateHandle::GenerateNewHandle );
-		HandlerAfterReferences->Add( NewDelegateHandle, NewHandlerPtr );
-		return NewDelegateHandle;
-	}
-
-	static void RemoveHandler(const FString& DebugSymbolName, FDelegateHandle InHandlerHandle )
+	template<typename HandlerType>
+	static void InternalRemoveHandler(FDelegateHandle HandlerHandle, HandlersArray<HandlerType>& Array, HandlersMap<HandlerType>& Map)
 	{
-		if ( HandlerBeforeReferences->Contains( InHandlerHandle ) )
+		if (TSharedPtr<HandlerType> HandlerPtr; Map.RemoveAndCopyValue(HandlerHandle, HandlerPtr))
 		{
-			const TSharedPtr<Handler> HandlerPtr = HandlerBeforeReferences->FindAndRemoveChecked( InHandlerHandle );
-			HandlersBefore->Remove( HandlerPtr );
+			Array.Remove(HandlerPtr);
 		}
-		if ( HandlerAfterReferences->Contains( InHandlerHandle ) )
-		{
-			const TSharedPtr<HandlerAfter> HandlerPtr = HandlerAfterReferences->FindAndRemoveChecked( InHandlerHandle );
-			HandlersAfter->Remove( HandlerPtr );
-		}
-
-		if ( HandlersAfter->IsEmpty() && HandlersBefore->IsEmpty() )
-		{
-			UninstallHook(DebugSymbolName);
-		}
-
-		InHandlerHandle.Reset();
 	}
-};
 
-//Hook invoker for member functions
-template <typename TCallable, TCallable Callable, bool bIsConst, typename ReturnType, typename CallableType, typename... ArgumentTypes>
-struct HookInvokerExecutorMemberFunction {
-public:
-	using ConstCorrectThisPtr = std::conditional_t<bIsConst, const CallableType*, CallableType*>;
-	using CallScopeFunctionSignature = ReturnType(*)(ConstCorrectThisPtr, ArgumentTypes...); 
-	typedef TCallScope<CallScopeFunctionSignature> ScopeType;
-	
-	typedef void HandlerSignature(ScopeType&, ConstCorrectThisPtr, ArgumentTypes...);
-	typedef typename HandlerAfterFunc<ReturnType, ConstCorrectThisPtr, ArgumentTypes...>::Value HandlerSignatureAfter;
-	typedef ReturnType HookType(ConstCorrectThisPtr, ArgumentTypes...);
-
-	using Handler = TFunction<HandlerSignature>;
-	using HandlerAfter = TFunction<HandlerSignatureAfter>;
-private:
-	static inline TArray<TSharedPtr<Handler>>* HandlersBefore{nullptr};
-	static inline TArray<TSharedPtr<HandlerAfter>>* HandlersAfter{nullptr};
-	static inline TMap<FDelegateHandle, TSharedPtr<Handler>>* HandlerBeforeReferences{nullptr};
-	static inline TMap<FDelegateHandle, TSharedPtr<HandlerAfter>>* HandlerAfterReferences{nullptr};
-	static inline HookType* FunctionPtr{nullptr};
-	static inline void* RealFunctionAddress{nullptr};
-	static inline bool bHookInitialized{false};
-
-	//Methods which return class/struct/union by value have out pointer inserted
-	//as first parameter after this pointer, with all arguments shifted right by 1 for it
-	//On Linux the out pointer goes before this pointer, so we don't need to do anything special
-	static ReturnType* ApplyCallUserTypeByValueWindows( CallableType* Self, ReturnType* OutReturnValue, ArgumentTypes... Args )
+	template<typename... /* ArgTypes */>
+	struct GenerateHookFunction
 	{
-		// Capture the pointer of the return value
-		// so ScopeType does not have to know about that special case
-		auto Trampoline = [&](ConstCorrectThisPtr Self_, ArgumentTypes... Args_) -> ReturnType
+		static ReturnType ApplyCall(ArgTypes... Args)
 		{
-			(reinterpret_cast<ReturnType*(*)(ConstCorrectThisPtr, ReturnType*, ArgumentTypes...)>(FunctionPtr))(Self_, OutReturnValue, Args_...);
-			return *OutReturnValue;
-		};
-
-		ScopeType Scope(HandlersBefore, Trampoline);
-		Scope(Self, Args...);
-		for ( const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter )
-		{
-			(*Handler)(Scope.GetResult(), Self, Args...);
+			ScopeType Scope(HandlersBefore, reinterpret_cast<CallableType*>(OriginalFunctionCode));
+			Scope(Args...);
+			if constexpr (std::is_void_v<ReturnType>)
+			{
+				for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
+				{
+					(*Handler)(Args...);
+				}
+			}
+			else
+			{
+				for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
+				{
+					(*Handler)(Scope.GetResult(), Args...);
+				}
+				return Scope.GetResult();
+			}
 		}
-		//We always return outReturnValue, so copy our result to output variable and return it
-		*OutReturnValue = Scope.GetResult();
-		return OutReturnValue;
-	}
+	};
 
-	//Normal scalar type call, where no additional arguments are inserted
-	//If it were returning user type by value, first argument would be R*, which is incorrect - that's why we need separate
-	//applyCallUserType with correct argument order
-	static ReturnType ApplyCallScalar(CallableType* Self, ArgumentTypes... Args)
-	{
-		ScopeType Scope(HandlersBefore, FunctionPtr);
-		Scope(Self, Args...);
-		for ( const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter )
-		{
-			(*Handler)(Scope.GetResult(), Self, Args...);
-		}
-		return Scope.GetResult();
-	}
-
-	//Call for void return type - nothing special to do with void
-	static void ApplyCallVoid(CallableType* Self, ArgumentTypes... Args)
-	{
-		ScopeType Scope(HandlersBefore, FunctionPtr);
-		Scope(Self, Args...);
-		for ( const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter )
-		{
-			(*Handler)(Self, Args...);
-		}
-	}
-
-    static void* GetApplyCall1(std::true_type) {
-    	return (void*) &ApplyCallVoid; //true - type is void
-    }
-	static void* GetApplyCall1(std::false_type) {
 #ifdef _WIN64
-		using Condition = std::disjunction<std::is_class<ReturnType>, std::is_union<ReturnType>>;
-#else
-		using Condition = std::false_type;
+	// Depending on the type of the return value, the ABI might require that the caller allocates memory
+	// for the result and passes a pointer to it as a hidden parameter to the function.
+	//
+	// We usually don't need to worry about this, the compiler will do the same to our hook function if
+	// needed and it will just work, however Windows has an exception for non-static member functions
+	// where it will pass the return address parameter after the "this" pointer. This is a problem for
+	// us because our hook functions are never actually non-static member functions, we just emulate
+	// them by having an explicit "this" parameter, so we can't rely on the compiler to do the right
+	// thing.
+	//
+	// Fortunately the rules are very simple on Windows: a non-static member function will never return
+	// a user-defined type (class/union) in a register, regardless of size or triviality.
+	//
+	// This isn't a problem on Linux because System V doesn't treat non-static member functions any
+	// differently, so emulating one with an explicit "this" parameter doesn't cause any issues.
+	template<typename ThisPointer, typename... OtherArgTypes>
+		requires (bIsMemberFunction && (std::is_class_v<ReturnType> || std::is_union_v<ReturnType>))
+	struct GenerateHookFunction<ThisPointer, OtherArgTypes...>
+	{
+		static ReturnType* ApplyCall(ThisPointer Self, ReturnType* OutReturnValue, OtherArgTypes... Args)
+		{
+			// Capture the pointer of the return value so ScopeType does not have to know about that special case.
+			auto Trampoline = [OutReturnValue](ThisPointer Self, OtherArgTypes... OtherArgs) -> ReturnType
+			{
+				reinterpret_cast<ReturnType*(*)(ThisPointer, ReturnType*, OtherArgTypes...)>(OriginalFunctionCode)(Self, OutReturnValue, OtherArgs...);
+				return *OutReturnValue;
+			};
+
+			ScopeType Scope(HandlersBefore, Trampoline);
+			Scope(Self, Args...);
+			for (const TSharedPtr<HandlerAfter>& Handler : *HandlersAfter)
+			{
+				(*Handler)(Scope.GetResult(), Self, Args...);
+			}
+			*OutReturnValue = Scope.GetResult();
+			return OutReturnValue;
+		}
+	};
 #endif
-	    return GetApplyCall2(Condition{}); //not a void, try call 2
-    }
-	static void* GetApplyCall2(std::true_type) {
-	    return (void*) &ApplyCallUserTypeByValueWindows; //true - type is class or union on Windows
-    }
-	static void* GetApplyCall2(std::false_type) {
-    	return (void*) &ApplyCallScalar; //false - type is scalar type or Linux
-    }
-	
-	static void* GetApplyCall() {
-    	return GetApplyCall1(std::is_same<ReturnType, void>{});
-	}
-public:
-	//Handles normal member function hooking, e.g hooking fixed symbol implementation in executable
-	static void InstallHook(const FString& DebugSymbolName, const void* SampleObjectInstance = NULL)
-	{
-		if (!bHookInitialized)
-		{
-			bHookInitialized = true;
-			void* HookFunctionPointer = GetApplyCall();
-			const FMemberFunctionPointer MemberFunctionPointer = ConvertFunctionPointer( Callable );
-			
-			RealFunctionAddress = FNativeHookManagerInternal::RegisterHookFunction( DebugSymbolName,
-				MemberFunctionPointer,
-				SampleObjectInstance,
-				HookFunctionPointer, (void**) &FunctionPtr );
-			
-			THandlerLists<Handler, HandlerAfter>* HandlerLists = CreateHandlerLists<Handler, HandlerAfter>( RealFunctionAddress );
 
-			HandlersBefore = &HandlerLists->HandlersBefore;
-			HandlersAfter = &HandlerLists->HandlersAfter;
-			HandlerBeforeReferences = &HandlerLists->HandlerBeforeReferences;
-			HandlerAfterReferences = &HandlerLists->HandlerAfterReferences;
-		}
-	}
-
-	// Uninstalls the hook. Also frees the handler lists object.
-	static void UninstallHook(const FString& DebugSymbolName)
-	{
-		if (bHookInitialized)
-		{
-			FNativeHookManagerInternal::UnregisterHookFunction( DebugSymbolName, RealFunctionAddress );
-			DestroyHandlerLists<Handler, HandlerAfter>( RealFunctionAddress );
-			bHookInitialized = false;
-			RealFunctionAddress = nullptr;
-			
-			HandlersBefore = nullptr;
-			HandlersAfter = nullptr;
-			HandlerBeforeReferences = nullptr;
-			HandlerAfterReferences = nullptr;
-		}
-	}
-
-	static FDelegateHandle AddHandlerBefore( Handler&& InHandler )
-	{
-		const TSharedPtr<Handler> NewHandlerPtr = MakeShared<Handler>( MoveTemp( InHandler ) );
-		HandlersBefore->Add( NewHandlerPtr );
-
-		FDelegateHandle NewDelegateHandle( FDelegateHandle::GenerateNewHandle );
-		HandlerBeforeReferences->Add( NewDelegateHandle, NewHandlerPtr );
-		return NewDelegateHandle;
-	}
-
-	static FDelegateHandle AddHandlerAfter( HandlerAfter&& InHandler ) {
-
-		const TSharedPtr<HandlerAfter> NewHandlerPtr = MakeShared<HandlerAfter>( MoveTemp( InHandler ) );
-		HandlersAfter->Add( NewHandlerPtr );
-
-		FDelegateHandle NewDelegateHandle( FDelegateHandle::GenerateNewHandle );
-		HandlerAfterReferences->Add( NewDelegateHandle, NewHandlerPtr );
-		return NewDelegateHandle;
-	}
-
-	static void RemoveHandler(const FString& DebugSymbolName, FDelegateHandle InHandlerHandle )
-	{
-		if ( HandlerBeforeReferences->Contains( InHandlerHandle ) )
-		{
-			const TSharedPtr<Handler> HandlerPtr = HandlerBeforeReferences->FindAndRemoveChecked( InHandlerHandle );
-			HandlersBefore->Remove( HandlerPtr );
-		}
-		if ( HandlerAfterReferences->Contains( InHandlerHandle ) )
-		{
-			const TSharedPtr<HandlerAfter> HandlerPtr = HandlerAfterReferences->FindAndRemoveChecked( InHandlerHandle );
-			HandlersAfter->Remove( HandlerPtr );
-		}
-
-		if ( HandlersAfter->IsEmpty() && HandlersBefore->IsEmpty() )
-		{
-			UninstallHook(DebugSymbolName);
-		}
-
-		InHandlerHandle.Reset();
-	}
+	static inline HandlersArray<HandlerBefore>* HandlersBefore;
+	static inline HandlersArray<HandlerAfter>* HandlersAfter;
+	static inline HandlersMap<HandlerBefore>* HandlerBeforeReferences;
+	static inline HandlersMap<HandlerAfter>* HandlerAfterReferences;
+	static inline void* OriginalFunctionCode;
+	static inline void* Key;
 };
 
-//Hook invoker for member non-const functions
-template<typename R, typename C, typename... A, R(C::*Callable)(A...)>
-struct HookInvoker<R(C::*)(A...), Callable> : HookInvokerExecutorMemberFunction<R(C::*)(A...), Callable, false, R, C, A...> {
-};
+// non-const non-static member function
+template<typename Backend, typename R, typename C, typename... A>
+struct THookInvoker<Backend, R(C::*)(A...)> : THookInvokerBase<Backend, true, R, C*, A...> {};
 
-//Hook invoker for member const functions
-template<typename R, typename C, typename... A, R(C::*Callable)(A...) const>
-struct HookInvoker<R(C::*)(A...) const, Callable> : HookInvokerExecutorMemberFunction<R(C::*)(A...) const, Callable, true, R, C, A...> {
-};
+// const non-static member function
+template<typename Backend, typename R, typename C, typename... A>
+struct THookInvoker<Backend, R(C::*)(A...) const> : THookInvokerBase<Backend, true, R, const C*, A...> {};
 
-//Hook invoker for global functions
-template<typename R, typename... A, R(*Callable)(A...)>
-struct HookInvoker<R(*)(A...), Callable> : HookInvokerExecutorGlobalFunction<R(*)(A...), Callable, R, A...> {
-};
-
+// free function or static member function
+template<typename Backend, typename R, typename... A>
+struct THookInvoker<Backend, R(*)(A...)> : THookInvokerBase<Backend, false, R, A...> {};
 
 UE_DEPRECATED( 5.2, "CallScope type is deprecated. Please migrate your code to use TCallScope" );
 template<typename T>
 using CallScope = TCallScope<T>;
 
+/*
+ * SUBSCRIBE_METHOD
+ * Will trigger a runtime error if the given method is virtual.
+ */
+
 #define SUBSCRIBE_METHOD(MethodReference, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&MethodReference), &MethodReference>::InstallHook(TEXT(#MethodReference)); \
-		return HookInvoker<decltype(&MethodReference), &MethodReference>::AddHandlerBefore(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT(decltype(&MethodReference), MethodReference, Handler)
 
 #define SUBSCRIBE_METHOD_AFTER(MethodReference, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&MethodReference), &MethodReference>::InstallHook(TEXT(#MethodReference)); \
-		return HookInvoker<decltype(&MethodReference), &MethodReference>::AddHandlerAfter(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT_AFTER(decltype(&MethodReference), MethodReference, Handler)
 
 #define SUBSCRIBE_METHOD_EXPLICIT(MethodSignature, MethodReference, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &MethodReference>::InstallHook(TEXT(#MethodReference)); \
-		return HookInvoker<MethodSignature, &MethodReference>::AddHandlerBefore(Handler); \
-	} )
+	INTERNAL_SUBSCRIBE_METHOD(Before, MethodSignature, MethodReference, Handler)
 
 #define SUBSCRIBE_METHOD_EXPLICIT_AFTER(MethodSignature, MethodReference, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &MethodReference>::InstallHook(TEXT(#MethodReference)); \
-		return HookInvoker<MethodSignature, &MethodReference>::AddHandlerAfter(Handler); \
-	} )
+	INTERNAL_SUBSCRIBE_METHOD(After, MethodSignature, MethodReference, Handler)
+
+#define INTERNAL_SUBSCRIBE_METHOD(HandlerKind, MethodSignature, MethodReference, Handler) \
+	THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
+		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference))
+
+/*
+ * SUBSCRIBE_METHOD_VIRTUAL
+ * Uses the vtable from the given instance to locate the function.
+ */
 
 #define SUBSCRIBE_METHOD_VIRTUAL(MethodReference, SampleObjectInstance, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&MethodReference), &MethodReference>::InstallHook(TEXT(#MethodReference), SampleObjectInstance); \
-		return HookInvoker<decltype(&MethodReference), &MethodReference>::AddHandlerBefore(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL(decltype(&MethodReference), MethodReference, SampleObjectInstance, Handler)
 
 #define SUBSCRIBE_METHOD_VIRTUAL_AFTER(MethodReference, SampleObjectInstance, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&MethodReference), &MethodReference>::InstallHook(TEXT(#MethodReference), SampleObjectInstance); \
-		return HookInvoker<decltype(&MethodReference), &MethodReference>::AddHandlerAfter(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL_AFTER(decltype(&MethodReference), MethodReference, SampleObjectInstance, Handler)
 
 #define SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL(MethodSignature, MethodReference, SampleObjectInstance, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &MethodReference>::InstallHook(TEXT(#MethodReference), SampleObjectInstance); \
-		return HookInvoker<MethodSignature, &MethodReference>::AddHandlerBefore(Handler); \
-	} )
+	INTERNAL_SUBSCRIBE_METHOD_VIRTUAL(Before, MethodSignature, MethodReference, SampleObjectInstance, Handler)
 
 #define SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL_AFTER(MethodSignature, MethodReference, SampleObjectInstance, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &MethodReference>::InstallHook(TEXT(#MethodReference), SampleObjectInstance); \
-		return HookInvoker<MethodSignature, &MethodReference>::AddHandlerAfter(Handler); \
-	} )
+	INTERNAL_SUBSCRIBE_METHOD_VIRTUAL(After, MethodSignature, MethodReference, SampleObjectInstance, Handler)
+
+#define INTERNAL_SUBSCRIBE_METHOD_VIRTUAL(HandlerKind, MethodSignature, MethodReference, SampleObjectInstance, Handler) \
+	THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
+		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance)
+
+/*
+ * SUBSCRIBE_UOBJECT_METHOD
+ * Uses the vtable from the CDO of the given class to locate the function.
+ */
 
 #define SUBSCRIBE_UOBJECT_METHOD(ObjectClass, MethodName, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&ObjectClass::MethodName), &ObjectClass::MethodName>::InstallHook(TEXT(#ObjectClass "::" #MethodName), GetDefault<ObjectClass>()); \
-		return HookInvoker<decltype(&ObjectClass::MethodName), &ObjectClass::MethodName>::AddHandlerBefore(Handler); \
-	} )
+	SUBSCRIBE_METHOD_VIRTUAL(ObjectClass::MethodName, GetDefault<ObjectClass>(), Handler)
 
 #define SUBSCRIBE_UOBJECT_METHOD_AFTER(ObjectClass, MethodName, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<decltype(&ObjectClass::MethodName), &ObjectClass::MethodName>::InstallHook(TEXT(#ObjectClass "::" #MethodName), GetDefault<ObjectClass>()); \
-		return HookInvoker<decltype(&ObjectClass::MethodName), &ObjectClass::MethodName>::AddHandlerAfter(Handler); \
-	} )
+	SUBSCRIBE_METHOD_VIRTUAL_AFTER(ObjectClass::MethodName, GetDefault<ObjectClass>(), Handler)
 
 #define SUBSCRIBE_UOBJECT_METHOD_EXPLICIT(MethodSignature, ObjectClass, MethodName, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &ObjectClass::MethodName>::InstallHook(TEXT(#ObjectClass "::" #MethodName), GetDefault<ObjectClass>()); \
-		return HookInvoker<MethodSignature, &ObjectClass::MethodName>::AddHandlerBefore(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL(MethodSignature, ObjectClass::MethodName, GetDefault<ObjectClass>(), Handler)
 
 #define SUBSCRIBE_UOBJECT_METHOD_EXPLICIT_AFTER(MethodSignature, ObjectClass, MethodName, Handler) \
-	Invoke( [&]() { \
-		HookInvoker<MethodSignature, &ObjectClass::MethodName>::InstallHook(TEXT(#ObjectClass "::" #MethodName), GetDefault<ObjectClass>()); \
-		return HookInvoker<MethodSignature, &ObjectClass::MethodName>::AddHandlerAfter(Handler); \
-	} )
+	SUBSCRIBE_METHOD_EXPLICIT_VIRTUAL_AFTER(MethodSignature, ObjectClass::MethodName, GetDefault<ObjectClass>(), Handler)
+
+/*
+ * UNSUBSCRIBE_METHOD
+ */
 
 #define UNSUBSCRIBE_METHOD(MethodReference, HandlerHandle) \
-	HookInvoker<decltype(&MethodReference), &MethodReference>::RemoveHandler(TEXT(#MethodReference), HandlerHandle )
+	UNSUBSCRIBE_METHOD_EXPLICIT(decltype(&MethodReference), MethodReference, HandlerHandle)
 
 #define UNSUBSCRIBE_METHOD_EXPLICIT(MethodSignature, MethodReference, HandlerHandle) \
-	HookInvoker<MethodSignature, &MethodReference>::RemoveHandler(TEXT(#MethodReference), HandlerHandle )
+	THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
+		::RemoveHandler(HandlerHandle, TEXT(#MethodReference))
 
 #define UNSUBSCRIBE_UOBJECT_METHOD(ObjectClass, MethodName, HandlerHandle) \
-	HookInvoker<decltype(&ObjectClass::MethodName), &ObjectClass::MethodName>::RemoveHandler(TEXT(#ObjectClass "::" #MethodName), HandlerHandle )
+	UNSUBSCRIBE_METHOD(ObjectClass::MethodName, HandlerHandle)
 
 #define UNSUBSCRIBE_UOBJECT_METHOD_EXPLICIT(MethodSignature, ObjectClass, MethodName, HandlerHandle) \
-	HookInvoker<MethodSignature, &ObjectClass::MethodName>::RemoveHandler(TEXT(#ObjectClass "::" #MethodName), HandlerHandle )
+	UNSUBSCRIBE_METHOD_EXPLICIT(MethodSignature, ObjectClass::MethodName, HandlerHandle)

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "CoreMinimal.h"
 #include "Reflection/FunctionThunkGenerator.h"
+#include "Traits/MemberFunctionPtrOuter.h"
 #include <type_traits>
 
 SML_API DECLARE_LOG_CATEGORY_EXTERN(LogNativeHookManager, Log, Log);
@@ -338,8 +339,22 @@ struct TStandardHookBackend
 {
 	// Key = RealFunctionAddress
 
+	static consteval auto GetNullSampleObject()
+	{
+		// Use a dummy nullptr_t instance on non-member functions to make it compile.
+		// The sample object isn't used in that case anyway.
+		if constexpr (std::is_member_function_pointer_v<TCallable>)
+		{
+			return static_cast<const TMemberFunctionPtrOuter_T<TCallable>*>(nullptr);
+		}
+		else
+		{
+			return nullptr;
+		}
+	}
+
 	template<auto HookFunction>
-	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const void* SampleObjectInstance = NULL)
+	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, decltype(GetNullSampleObject()) SampleObjectInstance = nullptr)
 	{
 		FNativeHookResult Result;
 
@@ -365,7 +380,7 @@ struct TVtableHookBackend
 	// Key = VtableEntry
 
 	template<auto HookFunction>
-	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const void* SampleObjectInstance)
+	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const TMemberFunctionPtrOuter_T<TCallable>* SampleObjectInstance)
 	{
 		FNativeHookResult Result;
 

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -403,7 +403,8 @@ private:
 
 	//Methods which return class/struct/union by value have out pointer inserted
 	//as first parameter after this pointer, with all arguments shifted right by 1 for it
-	static ReturnType* ApplyCallUserTypeByValue( CallableType* Self, ReturnType* OutReturnValue, ArgumentTypes... Args )
+	//On Linux the out pointer goes before this pointer, so we don't need to do anything special
+	static ReturnType* ApplyCallUserTypeByValueWindows( CallableType* Self, ReturnType* OutReturnValue, ArgumentTypes... Args )
 	{
 		// Capture the pointer of the return value
 		// so ScopeType does not have to know about that special case
@@ -453,19 +454,18 @@ private:
     	return (void*) &ApplyCallVoid; //true - type is void
     }
 	static void* GetApplyCall1(std::false_type) {
-	    return GetApplyCall2(std::is_class<ReturnType>{}); //not a void, try call 2
+#ifdef _WIN64
+		using Condition = std::disjunction<std::is_class<ReturnType>, std::is_union<ReturnType>>;
+#else
+		using Condition = std::false_type;
+#endif
+	    return GetApplyCall2(Condition{}); //not a void, try call 2
     }
 	static void* GetApplyCall2(std::true_type) {
-	    return (void*) &ApplyCallUserTypeByValue; //true - type is class
+	    return (void*) &ApplyCallUserTypeByValueWindows; //true - type is class or union on Windows
     }
 	static void* GetApplyCall2(std::false_type) {
-	    return GetApplyCall3(std::is_union<ReturnType>{});
-    }
-	static void* GetApplyCall3(std::true_type) {
-    	return (void*) &ApplyCallUserTypeByValue; //true - type is union
-    }
-	static void* GetApplyCall3(std::false_type) {
-    	return (void*) &ApplyCallScalar; //false - type is scalar type
+    	return (void*) &ApplyCallScalar; //false - type is scalar type or Linux
     }
 	
 	static void* GetApplyCall() {

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -2,6 +2,7 @@
 #include "CoreMinimal.h"
 #include "Reflection/FunctionThunkGenerator.h"
 #include "Traits/MemberFunctionPtrOuter.h"
+#include <concepts>
 #include <type_traits>
 
 SML_API DECLARE_LOG_CATEGORY_EXTERN(LogNativeHookManager, Log, Log);
@@ -163,6 +164,9 @@ struct TCallScope;
 template<typename ReturnType, typename... ArgTypes>
 class TCallScopeBase
 {
+	template<typename Backend, typename Variant, bool bIsMemberFunction, typename /*ReturnType*/, typename... /*ArgTypes*/>
+	friend class THookInvokerBase;
+
 	using DerivedCallScope = TCallScope<ReturnType(*)(ArgTypes...)>;
 	static constexpr bool bHasReturnValue = !std::is_void_v<ReturnType>;
 
@@ -182,7 +186,9 @@ public:
 
 	ReturnType operator()(ArgTypes... Args)
 	{
-		if (FunctionList == nullptr || HandlerIndex >= FunctionList->Num())
+		const ArgsPreprocessor<ArgTypes...> ArgsPreprocessor(*this, Args...);
+
+		if (FunctionList == nullptr || static_cast<size_t>(HandlerIndex) >= FunctionList->Num())
 		{
 			// Reached the end of the handler list, call the original function.
 			if constexpr (bHasReturnValue)
@@ -197,8 +203,8 @@ public:
 		}
 		else
 		{
-			const size_t CurrentHandlerIndex = HandlerIndex++;
-			const size_t NextHandlerIndex = HandlerIndex;
+			const uint32 CurrentHandlerIndex = HandlerIndex++;
+			const uint32 NextHandlerIndex = HandlerIndex;
 
 			// Call the current handler.
 			const TSharedPtr<HookCallable>& Handler = (*FunctionList)[CurrentHandlerIndex];
@@ -222,11 +228,61 @@ protected:
 	{
 	}
 
+	// We need a new variable to store ThisAdjustment, but we can't change the layout of this class
+	// because we need to maintain compatibility with mods that were compiled before this change. We
+	// also can't make use of existing padding because that won't necessarily be zero-initialized if an
+	// old mod creates the scope. Fortunately there's a really hacky way around this: HandlerIndex was
+	// size_t (64-bits) before, but we're obviously not going to have anywhere near that number of
+	// handlers, so the upper bits of that variable are always going to be zero. It's now restricted to
+	// a 32-bit value, which leaves the upper 32-bits for ThisAdjustment, The hacky thing about this is
+	// that we need to make sure that those upper bits are set back to zero whenever we call into old
+	// code, as it will be doing full 64-bit operations at that address.
+	static_assert(PLATFORM_LITTLE_ENDIAN && sizeof(size_t) == 8,
+		"TCallScope changes aren't backwards-compatible on this platform!");
+
 	const TArray<TSharedPtr<HookCallable>>* FunctionList;
-	size_t HandlerIndex = 0;
+	uint32 HandlerIndex = 0;	// Used to be size_t
+	uint32 ThisAdjustment = 0;
 	OrigCallable OrigFunc;
 	bool bForwardCall = true;
 	std::conditional_t<bHasReturnValue, std::remove_cv_t<ReturnType>, std::monostate> ResultData{};
+
+private:
+	template<typename... /* ArgTypes */>
+	struct ArgsPreprocessor
+	{
+		FORCEINLINE ArgsPreprocessor(const TCallScopeBase& Scope, const ArgTypes&...)
+		{
+			check(Scope.ThisAdjustment == 0);
+		}
+	};
+
+	// Pre-processing for the 'this' pointer in member functions.
+	// Technically this will also run for non-member functions that have a pointer as their first
+	// argument, but in those cases ThisAdjustment will be zero so this won't end up doing anything.
+	template<typename Pointee, typename... OtherArgTypes>
+	struct ArgsPreprocessor<Pointee*, OtherArgTypes...>
+	{
+		TCallScopeBase& Scope;
+		const uint32_t SavedThisAdjustment;
+
+		FORCEINLINE ArgsPreprocessor(TCallScopeBase& Scope, Pointee*& Ptr, const OtherArgTypes&...)
+			: Scope(Scope)
+			, SavedThisAdjustment(Scope.ThisAdjustment)
+		{
+			// Handlers un-apply the ThisAdjustment so that they can have sane pointers for their callbacks, but
+			// we need to re-apply it now as we're about to call into unknown code.
+			Ptr = reinterpret_cast<Pointee*>(reinterpret_cast<uintptr_t>(Ptr) + SavedThisAdjustment);
+
+			// Reset this to zero so it doesn't confuse old mods trying to use HandlerIndex.
+			Scope.ThisAdjustment = 0;
+		}
+
+		FORCEINLINE ~ArgsPreprocessor()
+		{
+			Scope.ThisAdjustment = SavedThisAdjustment;
+		}
+	};
 };
 
 // non-void return
@@ -353,6 +409,10 @@ struct FNativeHookResult
 	/// actual address and not some sort of (member/virtual) function pointer as it will be directly
 	/// jumped to.
 	void* OriginalFunctionCode;
+
+	/// Offset, in bytes, added to the 'this' pointer before the function was called.
+	/// Only relevant for non-static member functions, should be set to zero otherwise.
+	ptrdiff_t ThisAdjustment;
 };
 
 template<typename TCallable, TCallable OriginalFunction>
@@ -378,13 +438,15 @@ struct TStandardHookBackend
 	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, decltype(GetNullSampleObject()) SampleObjectInstance = nullptr)
 	{
 		FNativeHookResult Result;
+		const FMemberFunctionPointer OriginalFunctionData = ConvertFunctionPointer(OriginalFunction);
 
 		Result.Key = FNativeHookManagerInternal::RegisterHookFunction(
 			DebugSymbolName,
-			ConvertFunctionPointer(OriginalFunction),
+			OriginalFunctionData,
 			SampleObjectInstance,
 			(void*)HookFunction,
 			&Result.OriginalFunctionCode);
+		Result.ThisAdjustment = static_cast<ptrdiff_t>(OriginalFunctionData.ThisAdjustment);
 
 		return Result;
 	}
@@ -404,13 +466,15 @@ struct TVtableHookBackend
 	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const TMemberFunctionPtrOuter_T<TCallable>* SampleObjectInstance)
 	{
 		FNativeHookResult Result;
+		const FMemberFunctionPointer OriginalFunctionData = ConvertFunctionPointer(OriginalFunction);
 
 		Result.Key = FNativeHookManagerInternal::RegisterVtableHook(
 			DebugSymbolName,
-			ConvertFunctionPointer(OriginalFunction),
+			OriginalFunctionData,
 			SampleObjectInstance,
 			(void*)HookFunction,
 			&Result.OriginalFunctionCode);
+		Result.ThisAdjustment = static_cast<ptrdiff_t>(OriginalFunctionData.ThisAdjustment);
 
 		return Result;
 	}
@@ -445,6 +509,7 @@ struct TUFunctionHookBackend
 			FunctionName,
 			HookFunction,
 			(FNativeFuncPtr*)&Result.OriginalFunctionCode);
+		Result.ThisAdjustment = 0;
 
 		return Result;
 	}
@@ -474,19 +539,25 @@ public:
 	using HandlerBefore = TFunction<HandlerBeforeSignature>;
 	using HandlerAfter = TFunction<HandlerAfterSignature>;
 
-	template<typename... BackendArgTypes>
-	static auto AddHandlerBefore(HandlerBefore&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
+	template<std::convertible_to<HandlerBefore> InHandlerType, typename... BackendArgTypes>
+	static auto AddHandlerBefore(InHandlerType&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
 	{
 		InstallHook(DebugSymbolName, Forward<BackendArgTypes>(BackendArgs)...);
-		const FDelegateHandle DelegateHandle = InternalAddHandler(MoveTemp(InHandler), *HandlersBefore, *HandlerBeforeReferences);
+		const FDelegateHandle DelegateHandle = InternalAddHandler(
+			WrapHandler<HandlerBefore>(Forward<InHandlerType>(InHandler)),
+			*HandlersBefore,
+			*HandlerBeforeReferences);
 		return FNativeHookHandle::TDelayedInit<THookInvokerBase>(DelegateHandle, DebugSymbolName);
 	}
 
-	template<typename... BackendArgTypes>
-	static auto AddHandlerAfter(HandlerAfter&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
+	template<std::convertible_to<HandlerAfter> InHandlerType, typename... BackendArgTypes>
+	static auto AddHandlerAfter(InHandlerType&& InHandler, const TCHAR* DebugSymbolName, BackendArgTypes&&... BackendArgs)
 	{
 		InstallHook(DebugSymbolName, Forward<BackendArgTypes>(BackendArgs)...);
-		const FDelegateHandle DelegateHandle = InternalAddHandler(MoveTemp(InHandler), *HandlersAfter, *HandlerAfterReferences);
+		const FDelegateHandle DelegateHandle = InternalAddHandler(
+			WrapHandler<HandlerAfter>(Forward<InHandlerType>(InHandler)),
+			*HandlersAfter,
+			*HandlerAfterReferences);
 		return FNativeHookHandle::TDelayedInit<THookInvokerBase>(DelegateHandle, DebugSymbolName);
 	}
 
@@ -522,6 +593,7 @@ private:
 		HandlersAfter = &HandlerLists->HandlersAfter;
 		HandlerBeforeReferences = &HandlerLists->HandlerBeforeReferences;
 		HandlerAfterReferences = &HandlerLists->HandlerAfterReferences;
+		ThisAdjustment = Result.ThisAdjustment;
 		OriginalFunctionCode = Result.OriginalFunctionCode;
 		Key = Result.Key;
 	}
@@ -538,6 +610,7 @@ private:
 		HandlersAfter = nullptr;
 		HandlerBeforeReferences = nullptr;
 		HandlerAfterReferences = nullptr;
+		ThisAdjustment = 0;
 		OriginalFunctionCode = nullptr;
 		Key = nullptr;
 	}
@@ -651,10 +724,76 @@ private:
 	};
 #endif
 
+	// For some member functions we could end up with a 'this' pointer that has been adjusted to point
+	// to a base class, which won't be compatible with the derived class pointer that the handler is
+	// expecting. To work around this, we need to un-adjust the 'this' pointer before calling the
+	// handler. It's tempting to do this in the hook function itself, we could modify the parameter as
+	// soon as it's passed in and the new value could be passed on to all of the handlers, but we can't
+	// do that because we need to be backwards-compatible with old mods; if an old mod is the first to
+	// register the hook, then they'd define the hook function and they wouldn't know to do that
+	// adjustment. The only thing that we know we have control over is our own handler, so that's the
+	// only place where this can be done.
+	template<typename HandlerType, typename InHandlerType>
+	static HandlerType WrapHandler(InHandlerType&& InHandler)
+	{
+		if constexpr (!bIsMemberFunction)
+		{
+			// Non-member functions shouldn't have a ThisAdjustment.
+			check(ThisAdjustment == 0);
+			return Forward<InHandlerType>(InHandler);
+		}
+		else if (ThisAdjustment == 0)
+		{
+			// No adjustment, use the input handler as-is.
+			return Forward<InHandlerType>(InHandler);
+		}
+		else if constexpr (std::is_same_v<HandlerType, HandlerBefore>)
+		{
+			// HandlerBefore
+			return [Handler = Forward<InHandlerType>(InHandler)]
+				<typename Pointee, typename... OtherArgTypes>
+				(ScopeType& Scope, Pointee* This, OtherArgTypes&&... OtherArgs)
+			{
+				Scope.ThisAdjustment = ThisAdjustment;
+				This = reinterpret_cast<Pointee*>(reinterpret_cast<uintptr_t>(This) - ThisAdjustment);
+				Handler(Scope, This, Forward<OtherArgTypes>(OtherArgs)...);
+				Scope.ThisAdjustment = 0;
+			};
+		}
+		else
+		{
+			// HandlerAfter
+			static_assert(std::is_same_v<HandlerType, HandlerAfter>);
+			if constexpr (std::is_void_v<ReturnType>)
+			{
+				// void return
+				return [Handler = Forward<InHandlerType>(InHandler)]
+					<typename Pointee, typename... OtherArgTypes>
+					(Pointee* This, OtherArgTypes&&... OtherArgs)
+				{
+					This = reinterpret_cast<Pointee*>(reinterpret_cast<uintptr_t>(This) - ThisAdjustment);
+					Handler(This, Forward<OtherArgTypes>(OtherArgs)...);
+				};
+			}
+			else
+			{
+				// non-void return
+				return [Handler = Forward<InHandlerType>(InHandler)]
+					<typename Pointee, typename... OtherArgTypes>
+					(const ReturnType& ReturnValue, Pointee* This, OtherArgTypes&&... OtherArgs)
+				{
+					This = reinterpret_cast<Pointee*>(reinterpret_cast<uintptr_t>(This) - ThisAdjustment);
+					Handler(ReturnValue, This, Forward<OtherArgTypes>(OtherArgs)...);
+				};
+			}
+		}
+	}
+
 	static inline HandlersArray<HandlerBefore>* HandlersBefore;
 	static inline HandlersArray<HandlerAfter>* HandlersAfter;
 	static inline HandlersMap<HandlerBefore>* HandlerBeforeReferences;
 	static inline HandlersMap<HandlerAfter>* HandlerAfterReferences;
+	static inline ptrdiff_t ThisAdjustment;
 	static inline void* OriginalFunctionCode;
 	static inline void* Key;
 };

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -151,7 +151,8 @@ static void DestroyHandlerLists(void* Key)
 
 /// Manages handlers and invokes them when the hooked function is called.
 /// The actual hooking is delegated to the backend, which can decide how it wants to hook.
-template<typename Backend, typename TCallable>
+/// Variant is an unused parameter that you can change to get a different template instantiation.
+template<typename Backend, typename TCallable, typename Variant = void>
 struct THookInvoker;
 
 template<typename TCallable>
@@ -251,7 +252,7 @@ public:
 /// Otherwise you can safely ignore it.
 class FNativeHookHandle
 {
-	template<typename Backend, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
+	template<typename Backend, typename Variant, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
 	friend class THookInvokerBase;
 
 private:
@@ -419,7 +420,7 @@ struct TUFunctionHookBackend
 	}
 };
 
-template<typename Backend, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
+template<typename Backend, typename Variant, bool bIsMemberFunction, typename ReturnType, typename... ArgTypes>
 class THookInvokerBase
 {
 	static_assert(!bIsMemberFunction || sizeof...(ArgTypes) >= 1,
@@ -623,16 +624,19 @@ private:
 };
 
 // non-const non-static member function
-template<typename Backend, typename R, typename C, typename... A>
-struct THookInvoker<Backend, R(C::*)(A...)> : THookInvokerBase<Backend, true, R, C*, A...> {};
+template<typename Backend, typename Variant, typename R, typename C, typename... A>
+struct THookInvoker<Backend, R(C::*)(A...), Variant>
+	: THookInvokerBase<Backend, Variant, true, R, C*, A...> {};
 
 // const non-static member function
-template<typename Backend, typename R, typename C, typename... A>
-struct THookInvoker<Backend, R(C::*)(A...) const> : THookInvokerBase<Backend, true, R, const C*, A...> {};
+template<typename Backend, typename Variant, typename R, typename C, typename... A>
+struct THookInvoker<Backend, R(C::*)(A...) const, Variant>
+	: THookInvokerBase<Backend, Variant, true, R, const C*, A...> {};
 
 // free function or static member function
-template<typename Backend, typename R, typename... A>
-struct THookInvoker<Backend, R(*)(A...)> : THookInvokerBase<Backend, false, R, A...> {};
+template<typename Backend, typename Variant, typename R, typename... A>
+struct THookInvoker<Backend, R(*)(A...), Variant>
+	: THookInvokerBase<Backend, Variant, false, R, A...> {};
 
 UE_DEPRECATED( 5.2, "CallScope type is deprecated. Please migrate your code to use TCallScope" );
 template<typename T>
@@ -677,8 +681,12 @@ using CallScope = TCallScope<T>;
 	INTERNAL_SUBSCRIBE_METHOD_VIRTUAL(After, MethodSignature, MethodReference, SampleObjectInstance, Handler)
 
 #define INTERNAL_SUBSCRIBE_METHOD_VIRTUAL(HandlerKind, MethodSignature, MethodReference, SampleObjectInstance, Handler) \
-	THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
-		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance)
+	[&] { \
+		/* Each instantiation must be unique to support different SampleObjectInstance types at runtime. */ \
+		struct TotallyUniqueType; \
+		return THookInvoker<TStandardHookBackend<MethodSignature, &MethodReference>, MethodSignature, TotallyUniqueType> \
+			::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance); \
+	}()
 
 /*
  * SUBSCRIBE_UOBJECT_METHOD
@@ -721,8 +729,12 @@ using CallScope = TCallScope<T>;
 	INTERNAL_SUBSCRIBE_VTABLE_ENTRY(After, MethodSignature, MethodReference, SampleObjectInstance, Handler)
 
 #define INTERNAL_SUBSCRIBE_VTABLE_ENTRY(HandlerKind, MethodSignature, MethodReference, SampleObjectInstance, Handler) \
-	THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature> \
-		::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance)
+	[&] { \
+		/* Each instantiation must be unique to support different SampleObjectInstance types at runtime. */ \
+		struct TotallyUniqueType; \
+		return THookInvoker<TVtableHookBackend<MethodSignature, &MethodReference>, MethodSignature, TotallyUniqueType> \
+			::AddHandler##HandlerKind(Handler, TEXT(#MethodReference), SampleObjectInstance); \
+	}()
 
 /*
  * SUBSCRIBE_UFUNCTION_VM

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -156,95 +156,116 @@ static void DestroyHandlerLists(void* Key)
 template<typename Backend, typename TCallable, typename Variant = void>
 struct THookInvoker;
 
+/// Context object that hooks can use to control function execution.
 template<typename TCallable>
 struct TCallScope;
 
-//CallResult specialization for void
-template <typename... Args>
-struct TCallScope<void(*)(Args...)> {
-public:
-	typedef void HookType(Args...);
-	typedef void HookFuncSig(TCallScope<void(*)(Args...)>&, Args...);
-	typedef TFunction<HookFuncSig> HookFunc;
-
-private:
-	TArray<TSharedPtr<HookFunc>>* FunctionList;
-	SIZE_T HandlerPtr = 0;
-	HookType* Function;
-
-	bool bForwardCall = true;
+template<typename ReturnType, typename... ArgTypes>
+class TCallScopeBase
+{
+	using DerivedCallScope = TCallScope<ReturnType(*)(ArgTypes...)>;
+	static constexpr bool bHasReturnValue = !std::is_void_v<ReturnType>;
 
 public:
-	TCallScope(TArray<TSharedPtr<HookFunc>>* InFunctionList, HookType* InFunction) : FunctionList(InFunctionList), Function(InFunction) {}
+	// When the original function has a non-void return value, we store it as a TFunction instead of a
+	// regular function pointer so that the caller can abstract away any ABI shenanigans.
 
-	FORCEINLINE bool ShouldForwardCall() const {
+	using OrigFuncSignature = ReturnType(ArgTypes...);
+	using OrigCallable = std::conditional_t<bHasReturnValue, TFunction<OrigFuncSignature>, OrigFuncSignature*>;
+	using HookFuncSignature = void(DerivedCallScope&, ArgTypes...);
+	using HookCallable = TFunction<HookFuncSignature>;
+
+	bool ShouldForwardCall() const
+	{
 		return bForwardCall;
 	}
 
-	void Cancel() {
-		bForwardCall = false;
-	}
-
-	FORCEINLINE void operator()(Args... InArgs) {
-		if (FunctionList == nullptr || HandlerPtr >= FunctionList->Num()) {
-			Function(InArgs...);
+	ReturnType operator()(ArgTypes... Args)
+	{
+		if (FunctionList == nullptr || HandlerIndex >= FunctionList->Num())
+		{
+			// Reached the end of the handler list, call the original function.
+			if constexpr (bHasReturnValue)
+			{
+				ResultData = OrigFunc(Args...);
+			}
+			else
+			{
+				OrigFunc(Args...);
+			}
 			bForwardCall = false;
-		} else {
-			const SIZE_T CachePtr = HandlerPtr + 1;
-			const TSharedPtr<HookFunc>& Handler = (*FunctionList)[HandlerPtr++];
-			(*Handler)(*this, InArgs...);
-			if (HandlerPtr == CachePtr && bForwardCall) {
-				(*this)(InArgs...);
+		}
+		else
+		{
+			const size_t CurrentHandlerIndex = HandlerIndex++;
+			const size_t NextHandlerIndex = HandlerIndex;
+
+			// Call the current handler.
+			const TSharedPtr<HookCallable>& Handler = (*FunctionList)[CurrentHandlerIndex];
+			(*Handler)(static_cast<DerivedCallScope&>(*this), Args...);
+
+			// If the handler didn't call back into the scope, either by calling the next handler or overriding
+			// the result, then we do the next call for it.
+			if (HandlerIndex == NextHandlerIndex && bForwardCall)
+			{
+				(*this)(Args...);
 			}
 		}
+
+		return static_cast<ReturnType>(ResultData);
+	}
+
+protected:
+	TCallScopeBase(const TArray<TSharedPtr<HookCallable>>* FunctionList, OrigCallable OrigFunc)
+		: FunctionList(FunctionList)
+		, OrigFunc(MoveTemp(OrigFunc))
+	{
+	}
+
+	const TArray<TSharedPtr<HookCallable>>* FunctionList;
+	size_t HandlerIndex = 0;
+	OrigCallable OrigFunc;
+	bool bForwardCall = true;
+	std::conditional_t<bHasReturnValue, std::remove_cv_t<ReturnType>, std::monostate> ResultData{};
+};
+
+// non-void return
+template<typename ReturnType, typename... ArgTypes>
+struct TCallScope<ReturnType(*)(ArgTypes...)> : TCallScopeBase<ReturnType, ArgTypes...>
+{
+	using Base = TCallScopeBase<ReturnType, ArgTypes...>;
+
+	TCallScope(const TArray<TSharedPtr<typename Base::HookCallable>>* FunctionList, Base::OrigCallable OrigFunc)
+		: Base(FunctionList, OrigFunc)
+	{
+	}
+
+	ReturnType GetResult() const
+	{
+		return this->ResultData;
+	}
+
+	void Override(const ReturnType& NewResult)
+	{
+		this->bForwardCall = false;
+		this->ResultData = NewResult;
 	}
 };
 
-//general template for other types
-template <typename Result, typename... Args>
-struct TCallScope<Result(*)(Args...)> {
-public:
-	// typedef Result HookType(Args...);
-	typedef void HookFuncSig(TCallScope<Result(*)(Args...)>&, Args...);
-	typedef TFunction<HookFuncSig> HookFunc;
+// void return
+template<typename ReturnType, typename... ArgTypes> requires std::is_void_v<ReturnType>
+struct TCallScope<ReturnType(*)(ArgTypes...)> : TCallScopeBase<ReturnType, ArgTypes...>
+{
+	using Base = TCallScopeBase<ReturnType, ArgTypes...>;
 
-	typedef TFunction<Result(Args...)> HookType;
-private:
-	TArray<TSharedPtr<HookFunc>>* FunctionList;
-	size_t HandlerPtr = 0;
-	HookType Function;
-
-	bool bForwardCall = true;
-	Result ResultData{};
-public:
-	TCallScope(TArray<TSharedPtr<HookFunc>>* InFunctionList, HookType InFunction) : FunctionList(InFunctionList), Function(InFunction) {}
-
-	FORCEINLINE	bool ShouldForwardCall() const {
-		return bForwardCall;
+	TCallScope(const TArray<TSharedPtr<typename Base::HookCallable>>* FunctionList, Base::OrigCallable OrigFunc)
+		: Base(FunctionList, OrigFunc)
+	{
 	}
 
-	FORCEINLINE Result GetResult() {
-		return ResultData;
-	}
-
-	void Override(const Result& NewResult) {
-		bForwardCall = false;
-		ResultData = NewResult;
-	}
-
-	FORCEINLINE Result operator()(Args... args) {
-		if (FunctionList == nullptr || HandlerPtr >= FunctionList->Num()) {
-			ResultData = Function(args...);
-			this->bForwardCall = false;
-		} else {
-			const SIZE_T CachePtr = HandlerPtr + 1;
-			const TSharedPtr<HookFunc>& Handler = (*FunctionList)[HandlerPtr++];
-			(*Handler)(*this, args...);
-			if (HandlerPtr == CachePtr && bForwardCall) {
-				(*this)(args...);
-			}
-		}
-		return ResultData;
+	void Cancel()
+	{
+		this->bForwardCall = false;
 	}
 };
 

--- a/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
+++ b/Mods/SML/Source/SML/Public/Patching/NativeHookManager.h
@@ -104,18 +104,19 @@ class SML_API FNativeHookManagerInternal {
 public:
 	static void* GetHandlerListInternal(const void* Key);
 	static void SetHandlerListInstanceInternal(void* Key, void* HandlerList);
-	static void* RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
+	static void* RegisterHookFunction(const TCHAR* DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
 	                                  void* HookFunctionPointer, void** OutTrampolineFunction);
-	static void UnregisterHookFunction(const FString& DebugSymbolName, const void* RealFunctionAddress);
-	static void** RegisterVtableHook(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
+	static void UnregisterHookFunction(const TCHAR* DebugSymbolName, const void* RealFunctionAddress);
+	static void** RegisterVtableHook(const TCHAR* DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance,
 	                                 void* HookFunctionPointer, void** OutOriginalFunction);
-	static void UnregisterVtableHook(const FString& DebugSymbolName, void** VtableEntry);
-	static UFunction* RegisterUFunctionHook(UClass* Class, FName FunctionName, FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction);
-	static void UnregisterUFunctionHook(const FString& DebugSymbolName, UFunction* Function);
+	static void UnregisterVtableHook(const TCHAR* DebugSymbolName, void** VtableEntry);
+	static UFunction* RegisterUFunctionHook(const TCHAR* DebugSymbolName, UClass* Class, FName FunctionName,
+	                                        FNativeFuncPtr HookFunctionPointer, FNativeFuncPtr* OutOriginalFunction);
+	static void UnregisterUFunctionHook(const TCHAR* DebugSymbolName, UFunction* Function);
 
-	// A call to this function signature is inlined in mods
-	// Keep it for backwards compatibility
+	// Calls to these functions are inlined in mods, keep them for backwards compatibility.
 	static void* RegisterHookFunction(const FString& DebugSymbolName, void* OriginalFunctionPointer, const void* SampleObjectInstance, int ThisAdjustment, void* HookFunctionPointer, void** OutTrampolineFunction);
+	static void* RegisterHookFunction(const FString& DebugSymbolName, FMemberFunctionPointer MemberFunctionPointer, const void* SampleObjectInstance, void* HookFunctionPointer, void** OutTrampolineFunction);
 };
 
 template <typename T, typename E>
@@ -264,7 +265,7 @@ struct TStandardHookBackend
 	// Key = RealFunctionAddress
 
 	template<auto HookFunction>
-	static FNativeHookResult RegisterHook(const FString& DebugSymbolName, const void* SampleObjectInstance = NULL)
+	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const void* SampleObjectInstance = NULL)
 	{
 		FNativeHookResult Result;
 
@@ -278,7 +279,7 @@ struct TStandardHookBackend
 		return Result;
 	}
 
-	static void UnregisterHook(const FString& DebugSymbolName, void* RealFunctionAddress)
+	static void UnregisterHook(const TCHAR* DebugSymbolName, void* RealFunctionAddress)
 	{
 		FNativeHookManagerInternal::UnregisterHookFunction(DebugSymbolName, RealFunctionAddress);
 	}
@@ -290,7 +291,7 @@ struct TVtableHookBackend
 	// Key = VtableEntry
 
 	template<auto HookFunction>
-	static FNativeHookResult RegisterHook(const FString& DebugSymbolName, const void* SampleObjectInstance)
+	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, const void* SampleObjectInstance)
 	{
 		FNativeHookResult Result;
 
@@ -304,7 +305,7 @@ struct TVtableHookBackend
 		return Result;
 	}
 
-	static void UnregisterHook(const FString& DebugSymbolName, void* Key)
+	static void UnregisterHook(const TCHAR* DebugSymbolName, void* Key)
 	{
 		auto VtableEntry = static_cast<void**>(Key);
 		FNativeHookManagerInternal::UnregisterVtableHook(DebugSymbolName, VtableEntry);
@@ -324,11 +325,12 @@ struct TUFunctionHookBackend
 	}
 
 	template<FNativeFuncPtr HookFunction>
-	static FNativeHookResult RegisterHook(FName FunctionName)
+	static FNativeHookResult RegisterHook(const TCHAR* DebugSymbolName, FName FunctionName)
 	{
 		FNativeHookResult Result;
 
 		Result.Key = FNativeHookManagerInternal::RegisterUFunctionHook(
+			DebugSymbolName,
 			ClassType::StaticClass(),
 			FunctionName,
 			HookFunction,
@@ -337,7 +339,7 @@ struct TUFunctionHookBackend
 		return Result;
 	}
 
-	static void UnregisterHook(const FString& DebugSymbolName, void* Key)
+	static void UnregisterHook(const TCHAR* DebugSymbolName, void* Key)
 	{
 		auto Function = static_cast<UFunction*>(Key);
 		FNativeHookManagerInternal::UnregisterUFunctionHook(DebugSymbolName, Function);
@@ -688,7 +690,7 @@ using CallScope = TCallScope<T>;
 
 #define INTERNAL_SUBSCRIBE_UFUNCTION_VM(HandlerKind, ObjectClass, MethodName, Handler) \
 	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \
-		::AddHandler##HandlerKind(Handler, TEXT(#MethodName))
+		::AddHandler##HandlerKind(Handler, TEXT(#ObjectClass "::" #MethodName), TEXT(#MethodName))
 
 #define UNSUBSCRIBE_UFUNCTION_VM(ObjectClass, MethodName, HandlerHandle) \
 	THookInvoker<TUFunctionHookBackend<ObjectClass, &ObjectClass::MethodName>, decltype(&ObjectClass::MethodName)> \

--- a/Mods/SML/Source/SML/Public/Reflection/FunctionThunkGenerator.h
+++ b/Mods/SML/Source/SML/Public/Reflection/FunctionThunkGenerator.h
@@ -1,0 +1,251 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Script.h"
+#include "UObject/ScriptMacros.h"
+#include "UObject/Stack.h"
+
+#include <tuple>
+#include <type_traits>
+
+/**
+ * Generates a UFunction thunk (equivalent to what UHT would generate) given a function signature.
+ * The thunk is templated on a callback that will be invoked with the parameters from the stack.
+ */
+template<typename FunctionType>
+class TFunctionThunkGenerator;
+
+namespace FunctionThunkGenerator_Detail
+{
+	/*
+	 * ArgTraits
+	 * Type-specific details, specialized for each support argument type.
+	 */
+
+	template<typename T>
+	struct ArgTraitsImpl;
+
+	template<typename T>
+	using ArgTraits = ArgTraitsImpl<std::decay_t<T>>;
+
+	// Integers
+	template<> struct ArgTraitsImpl<int8> { using PropertyType = FInt8Property; };
+	template<> struct ArgTraitsImpl<int16> { using PropertyType = FInt16Property; };
+	template<> struct ArgTraitsImpl<int32> { using PropertyType = FIntProperty; };
+	template<> struct ArgTraitsImpl<int64> { using PropertyType = FInt64Property; };
+	template<> struct ArgTraitsImpl<uint8> { using PropertyType = FByteProperty; };
+	template<> struct ArgTraitsImpl<uint16> { using PropertyType = FUInt16Property; };
+	template<> struct ArgTraitsImpl<uint32> { using PropertyType = FUInt32Property; };
+	template<> struct ArgTraitsImpl<uint64> { using PropertyType = FUInt64Property; };
+
+	// Bool specialized to use (up to) 32-bit values.
+	template<>
+	struct ArgTraitsImpl<bool>
+	{
+		using PropertyType = FBoolProperty;
+
+		static FORCEINLINE void OverrideGetValue(bool& Result, FFrame& Stack)
+		{
+			uint32 Temp = 0;
+			Stack.StepCompiledIn<FBoolProperty>(&Temp);
+			Result = !!Temp;
+		}
+	};
+
+	// Structs
+	template<typename T> requires (!!TModels<CStaticStructProvider, T>::Value)
+	struct ArgTraitsImpl<T>
+	{
+		using PropertyType = FStructProperty;
+	};
+
+	// Objects
+	template<typename T> requires (!!TModels<CStaticClassProvider, T>::Value)
+	struct ArgTraitsImpl<T*>
+	{
+		using PropertyType = FObjectPropertyBase;
+	};
+
+	// Classes
+	template<typename ClassType>
+	struct ArgTraitsImpl<TSubclassOf<ClassType>>
+	{
+		using PropertyType = FObjectProperty;
+	};
+
+	// Arrays
+	template<typename T>
+	struct ArgTraitsImpl<TArray<T>>
+	{
+		using PropertyType = FArrayProperty;
+	};
+
+	// Maps
+	template<typename KeyType, typename ValueType>
+	struct ArgTraitsImpl<TMap<KeyType, ValueType>>
+	{
+		using PropertyType = FMapProperty;
+	};
+
+	// Sets
+	template<typename ElementType>
+	struct ArgTraitsImpl<TSet<ElementType>>
+	{
+		using PropertyType = FSetProperty;
+	};
+
+	// Interfaces
+	template<typename InterfaceType>
+	struct ArgTraitsImpl<TScriptInterface<InterfaceType>>
+	{
+		using PropertyType = FInterfaceProperty;
+	};
+
+	// Weak Object Pointers
+	template<typename T>
+	struct ArgTraitsImpl<TWeakObjectPtr<T>>
+	{
+		using PropertyType = FWeakObjectProperty;
+	};
+
+	// Soft Object Pointers
+	template<typename T>
+	struct ArgTraitsImpl<TSoftObjectPtr<T>>
+	{
+		using PropertyType = FSoftObjectProperty;
+	};
+
+	// Soft Class Pointers
+	template<typename T>
+	struct ArgTraitsImpl<TSoftClassPtr<T>>
+	{
+		using PropertyType = FSoftClassProperty;
+	};
+
+	// Field Paths
+	template<typename InPropertyType>
+	struct ArgTraitsImpl<TFieldPath<InPropertyType>>
+	{
+		using PropertyType = FFieldPathProperty;
+	};
+
+	// Enums
+	template<typename T> requires (!!TIsUEnumClass<T>::Value)
+	struct ArgTraitsImpl<T>
+	{
+		using PropertyType = FEnumProperty;
+	};
+
+	/*
+	 * ArgReader
+	 * Pops a single typed object off the stack and stores it.
+	 */
+
+	template<typename T>
+	struct ArgReaderImpl
+	{
+		T Value = {};
+
+		explicit ArgReaderImpl(FFrame& Stack)
+		{
+			if constexpr (requires { ArgTraits<T>::OverrideGetValue(Value, Stack); })
+			{
+				ArgTraits<T>::OverrideGetValue(Value, Stack);
+			}
+			else
+			{
+				Stack.StepCompiledIn<typename ArgTraits<T>::PropertyType>(&Value);
+			}
+		}
+	};
+
+	template<typename T>
+	struct ArgReaderImpl<T&>
+	{
+		T DefaultValue = {};
+		T& Value;
+
+		explicit ArgReaderImpl(FFrame& Stack)
+			: Value(Stack.StepCompiledInRef<typename ArgTraits<T>::PropertyType, T>(&DefaultValue))
+		{
+		}
+	};
+
+	// Arguments are all read as non-const, if any of them are const then that will be enforced in the
+	// callback function signature.
+	template<typename T>
+	using ArgReader = ArgReaderImpl<
+		std::conditional_t<std::is_reference_v<T>, std::remove_cvref_t<T>&, std::remove_cv_t<T>>>;
+
+	/*
+	 * TFunctionThunkGeneratorBase
+	 * Base implementation that takes the arguments and return value as separate parameters so that it's
+	 * independent of function type.
+	 */
+
+	template<
+		typename Ret,
+		typename OptionalInstanceTuple,
+		typename ArgsTuple,
+		typename ArgsIndexSequence = std::make_index_sequence<std::tuple_size_v<ArgsTuple>>>
+	class TFunctionThunkGeneratorBase;
+
+	template<typename Ret, typename... OptionalInstance, typename... Args, size_t... ArgIndices>
+	class TFunctionThunkGeneratorBase<
+		Ret,
+		std::tuple<OptionalInstance...>,
+		std::tuple<Args...>,
+		std::index_sequence<ArgIndices...>>
+	{
+	public:
+		template<Ret(*Impl)(OptionalInstance*..., Args...)>
+		static void Thunk(UObject* Context, FFrame& Stack, RESULT_DECL)
+		{
+			std::tuple ArgValues{ArgReader<Args>(Stack)...};
+			P_FINISH;
+			P_NATIVE_BEGIN;
+			if constexpr (!std::is_void_v<Ret>)
+			{
+				*(Ret*)RESULT_PARAM = InvokeImpl<Impl>(Context, ArgValues);
+			}
+			else
+			{
+				InvokeImpl<Impl>(Context, ArgValues);
+			}
+			P_NATIVE_END;
+		}
+
+	private:
+		template<auto Impl>
+		static FORCEINLINE decltype(auto) InvokeImpl(UObject* Context, auto&& ArgValues)
+		{
+			return Impl(
+				static_cast<OptionalInstance*>(Context)...,
+				std::get<ArgIndices>(ArgValues).Value...);
+		}
+	};
+}
+
+// Static function.
+template<typename Ret, typename... Args>
+class TFunctionThunkGenerator<Ret(*)(Args...)>
+	: public FunctionThunkGenerator_Detail::TFunctionThunkGeneratorBase<
+		Ret,
+		std::tuple<>,
+		std::tuple<Args...>> {};
+
+// Non-static member function.
+template<typename Ret, typename InstanceType, typename... Args>
+class TFunctionThunkGenerator<Ret(InstanceType::*)(Args...)>
+	: public FunctionThunkGenerator_Detail::TFunctionThunkGeneratorBase<
+		Ret,
+		std::tuple<InstanceType>,
+		std::tuple<Args...>> {};
+
+// Const non-static member function.
+template<typename Ret, typename InstanceType, typename... Args>
+class TFunctionThunkGenerator<Ret(InstanceType::*)(Args...) const>
+	: public FunctionThunkGenerator_Detail::TFunctionThunkGeneratorBase<
+		Ret,
+		std::tuple<const InstanceType>,
+		std::tuple<Args...>> {};


### PR DESCRIPTION
1. Added two new hook types: Vtable and UFunction. These are intended to be used in the cases where compiler optimizations have made the functions un-hookable with the normal methods, e.g. if they have been merged with other (unrelated) functions.
2. Fixed a crash on Linux when hooking a member function that returns a class.
3. Fixed various issues when hooking virtual functions when multiple inheritance is involved.

Tests added in a PR here: https://github.com/satisfactorymodding/SMLFeatureTests/pull/3