### PR TITLE
Fix for redirect hooks not working on expressions of class type

### DIFF
--- a/Mods/SML/Source/SML/Private/Toolkit/ScriptExprTypeResolver.cpp
+++ b/Mods/SML/Source/SML/Private/Toolkit/ScriptExprTypeResolver.cpp
@@ -95,7 +95,7 @@ TSharedPtr<FScriptExprType> FScriptExprType::CreateInterfaceProperty(UClass* Int
 
 TSharedPtr<FScriptExprType> FScriptExprType::CreateClassProperty(UClass* MetaClass, UClass* PropertyClass) {
 	const TSharedPtr<FScriptExprType> ClassProperty = CreateProperty<FClassProperty>();
-	ClassProperty->Operands.Add(PropertyClass ? PropertyClass : (MetaClass ? MetaClass->GetClass() : UClass::StaticClass()));
+	ClassProperty->Operands.Add(PropertyClass ? PropertyClass : UClass::StaticClass());
 	ClassProperty->Operands.Add(FScriptExprTypeOperand()); // class properties do not have attached implemented interface
 	ClassProperty->Operands.Add(MetaClass ? MetaClass : UObject::StaticClass());
 	return ClassProperty;


### PR DESCRIPTION
SML was using the meta-class's class as the property class, e.g. if it was a blueprint then it'd use UBlueprintGeneratedClass. However the engine (in FKismetCompilerUtilities::CreatePrimitiveProperty) will always use UClass, which results in a mismatch which is especially bad for redirect hooks as they require an exact match.