### PR TITLE
Fix sender colors in scripted chat messages

### DIFF
--- a/Mods/SML/Source/SML/Private/Player/SMLRemoteCallObject.cpp
+++ b/Mods/SML/Source/SML/Private/Player/SMLRemoteCallObject.cpp
@@ -30,9 +30,10 @@ void USMLRemoteCallObject::SendChatMessage_Implementation(const FString& Message
 	if (ChatManager) {
 		FChatMessageStruct MessageStruct;
 		MessageStruct.MessageText = FText::FromString(Message);
-		MessageStruct.MessageType = EFGChatMessageType::CMT_SystemMessage;
+		MessageStruct.MessageType = EFGChatMessageType::CMT_CustomMessage;
 		MessageStruct.ServerTimeStamp = GetGameState()->GetServerWorldTimeSeconds();
 		MessageStruct.MessageSenderColor = Color;
+		MessageStruct.MessageSender = FText::FromString(TEXT("System"));
 		ChatManager->AddChatMessageToReceived(MessageStruct);
 	} else {
 		UE_LOG(LogSatisfactoryModLoader, Error, TEXT("A mod tried to send a chat message before the game's ChatManager was ready! It has been prevented to avoid a crash. The mod developer must fix this by waiting for the chat manager to be valid. The message would have been: %s"), *Message);


### PR DESCRIPTION
Chat sender colors only work in Custom message types